### PR TITLE
Capture timeout events in URL crawl status

### DIFF
--- a/reciperadar/models/url.py
+++ b/reciperadar/models/url.py
@@ -42,6 +42,7 @@ class BaseURL(AbstractConcreteBase, Storable):
         429: 'Crawler rate-limit exceeded',
         500: 'Scraper failure occurred',
         501: 'Website not supported',
+        598: 'Network read timeout error',
     }
 
     # By default TLDExtract pulls a subdomain suffix list from the web;

--- a/reciperadar/models/url.py
+++ b/reciperadar/models/url.py
@@ -73,7 +73,12 @@ class BaseURL(AbstractConcreteBase, Storable):
         if backoff and (self.crawled_at + backoff) > datetime.utcnow():
             raise RecipeURL.BackoffException()
 
-        response = self._make_request()
+        try:
+            response = self._make_request()
+        except requests.exceptions.Timeout:
+            response = requests.Response()
+            response.status_code = 598
+
         self.crawl_status = response.status_code
         self.crawled_at = datetime.utcnow()
         return response

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -30,6 +30,7 @@ def test_crawl_timeout(get, origin_url):
     url.crawl()
 
     assert url.crawl_status == 598
+    assert 'timeout' in url.error_message
 
 
 @responses.activate

--- a/tests/models/test_url.py
+++ b/tests/models/test_url.py
@@ -1,4 +1,6 @@
+from mock import patch
 import pytest
+import requests
 import responses
 
 from reciperadar.models.url import CrawlURL, RecipeURL
@@ -18,6 +20,16 @@ def test_origin_url_domain(origin_url):
     url = CrawlURL(url=origin_url)
 
     assert url.domain == 'example.com'
+
+
+@patch('requests.get')
+def test_crawl_timeout(get, origin_url):
+    get.side_effect = [requests.exceptions.Timeout]
+
+    url = CrawlURL(url=origin_url)
+    url.crawl()
+
+    assert url.crawl_status == 598
 
 
 @responses.activate


### PR DESCRIPTION
Prior to this change, timeouts were not visible via crawl status code, since no response is returned by the `requests` library after a timeout (instead it throws an exception).

This change substitutes a crawler response using the unofficial [HTTP 598 network read timeout](https://web.archive.org/web/20170107115008/http://www.ascii-code.com/http-status-codes.php) status.