### PR TITLE
Improve match_all query behaviour

### DIFF
--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -208,7 +208,8 @@ class Recipe(Storable, Searchable):
                     'bool': {
                         'must' if match_all else 'should': include_clause,
                         'must_not': exclude_clause,
-                        'filter': filter_clause
+                        'filter': filter_clause,
+                        'minimum_should_match': None if match_all else 1
                     }
                 },
                 'script_score': {'script': {'source': sort_params['script']}}

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -212,7 +212,7 @@ class Recipe(Storable, Searchable):
                 'boost_mode': 'replace',
                 'query': {
                     'bool': {
-                        'must': must or {'match_all': {}},
+                        'must': must,
                         'should': should,
                         'must_not': must_not,
                         'filter': filter


### PR DESCRIPTION
- An empty-list in the `must` clause seems to be interpreted by Elasticsearch the same way as a `match_all` clause - so this change ensures that *either* a `must` *or* a `should` list is present, but not both
- Apply a `minimum_should_match` value of `1` for queries which may match on a subset of ingredients, setting a minimum level of recipe relevancy
- Refactoring to reduce the number of steps involved in query creation