### PR TITLE
Add support for vessels in the api

### DIFF
--- a/reciperadar/models/recipes/direction.py
+++ b/reciperadar/models/recipes/direction.py
@@ -9,6 +9,7 @@ from sqlalchemy.orm import relationship
 from reciperadar.models.base import Storable
 from reciperadar.models.recipes.appliance import DirectionAppliance
 from reciperadar.models.recipes.utensil import DirectionUtensil
+from reciperadar.models.recipes.vessel import DirectionVessel
 
 
 class RecipeDirection(Storable):
@@ -30,6 +31,11 @@ class RecipeDirection(Storable):
         backref='recipe_directions',
         passive_deletes='all'
     )
+    vessels = relationship(
+        'DirectionVessel',
+        backref='recipe_directions',
+        passive_deletes='all'
+    )
 
     @staticmethod
     def from_doc(doc, matches=None):
@@ -45,6 +51,10 @@ class RecipeDirection(Storable):
             utensils=[
                 DirectionUtensil.from_doc(utensil)
                 for utensil in doc.get('utensils', [])
+            ],
+            vessels=[
+                DirectionVessel.from_doc(vessel)
+                for vessel in doc.get('vessels', [])
             ]
         )
 
@@ -56,6 +66,9 @@ class RecipeDirection(Storable):
         ] + [
             {'equipment': utensil.utensil}
             for utensil in self.utensils
+        ] + [
+            {'equipment': vessel.vessel}
+            for vessel in self.vessels
         ]
         return data
 

--- a/reciperadar/models/recipes/vessel.py
+++ b/reciperadar/models/recipes/vessel.py
@@ -1,0 +1,25 @@
+from sqlalchemy import (
+    Column,
+    ForeignKey,
+    String,
+)
+
+from reciperadar.models.base import Storable
+
+
+class DirectionVessel(Storable):
+    __tablename__ = 'direction_vessels'
+
+    fk = ForeignKey('recipe_directions.id', ondelete='cascade')
+    direction_id = Column(String, fk, index=True)
+
+    id = Column(String, primary_key=True)
+    vessel = Column(String)
+
+    @staticmethod
+    def from_doc(doc):
+        vessel_id = doc.get('id') or DirectionVessel.generate_id()
+        return DirectionVessel(
+            id=vessel_id,
+            vessel=doc['vessel'],
+        )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,11 @@ def raw_recipe_hit():
                         {
                             "utensil": "skewer"
                         }
+                    ],
+                    "vessels": [
+                        {
+                            "vessel": "casserole dish"
+                        }
                     ]
                 }
             ],

--- a/tests/models/recipes/test_recipe.py
+++ b/tests/models/recipes/test_recipe.py
@@ -6,3 +6,4 @@ def test_recipe_from_doc(raw_recipe_hit):
 
     assert recipe.directions[0].appliances[0].appliance == 'oven'
     assert recipe.directions[0].utensils[0].utensil == 'skewer'
+    assert recipe.directions[0].vessels[0].vessel == 'casserole dish'


### PR DESCRIPTION
Given that information about `vessels` has been made available by the `direction-parser` service as part of https://github.com/openculinary/direction-parser/pull/3 , store this data in the `api` and make it available for equipment search.