### PR TITLE
Robot search considerations

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,7 @@ python-dateutil = "==2.8.1"
 requests = "==2.22.0"
 SQLAlchemy = "==1.3.11"
 tldextract = "==2.2.2"
+user-agents = "==2.0"
 watchdog = "==0.9.0"
 
 [dev-packages]

--- a/reciperadar/api/search.py
+++ b/reciperadar/api/search.py
@@ -1,4 +1,5 @@
 from flask import jsonify, request
+from user_agents import parse as ua_parser
 
 from reciperadar import app
 from reciperadar.models.events.search import SearchEvent
@@ -25,10 +26,6 @@ def ingredients():
     return jsonify(results)
 
 
-def is_robot(user_agent):
-    return user_agent and 'www.uptimerobot.com' in user_agent
-
-
 @app.route('/api/recipes/search')
 def recipes():
     include = request.args.getlist('include[]')
@@ -40,7 +37,7 @@ def recipes():
     results = Recipe().search(include, exclude, equipment, offset, limit, sort)
 
     user_agent = request.headers.get('user-agent')
-    suspected_bot = is_robot(user_agent)
+    suspected_bot = ua_parser(user_agent or '').is_bot
 
     # Perform a recrawl for the search to find any new/missing recipes
     recrawl_search.delay(include, exclude, equipment, offset)

--- a/reciperadar/api/search.py
+++ b/reciperadar/api/search.py
@@ -40,21 +40,22 @@ def recipes():
     results = Recipe().search(include, exclude, equipment, offset, limit, sort)
 
     user_agent = request.headers.get('user-agent')
-    if not is_robot(user_agent):
+    suspected_bot = is_robot(user_agent)
 
-        # Perform a recrawl for the search to find any new/missing recipes
-        recrawl_search.delay(include, exclude, equipment, offset)
+    # Perform a recrawl for the search to find any new/missing recipes
+    recrawl_search.delay(include, exclude, equipment, offset)
 
-        # TODO: Once 'event' is json serializable: switch to store_event.delay
-        store_event(SearchEvent(
-            include=include,
-            exclude=exclude,
-            equipment=equipment,
-            offset=offset,
-            limit=limit,
-            sort=sort,
-            results_ids=[result['id'] for result in results['results']],
-            results_total=results['total']
-        ))
+    # TODO: Once 'event' is json serializable: switch to store_event.delay
+    store_event(SearchEvent(
+        suspected_bot=suspected_bot,
+        include=include,
+        exclude=exclude,
+        equipment=equipment,
+        offset=offset,
+        limit=limit,
+        sort=sort,
+        results_ids=[result['id'] for result in results['results']],
+        results_total=results['total']
+    ))
 
     return jsonify(results)

--- a/reciperadar/api/search.py
+++ b/reciperadar/api/search.py
@@ -31,7 +31,7 @@ def recipes():
     include = request.args.getlist('include[]')
     exclude = request.args.getlist('exclude[]')
     equipment = request.args.getlist('equipment[]')
-    offset = min(request.args.get('offset', type=int, default=0), (50*10)-10)
+    offset = min(request.args.get('offset', type=int, default=0), (25*10)-10)
     limit = min(request.args.get('limit', type=int, default=10), 10)
     sort = request.args.get('sort')
     results = Recipe().search(include, exclude, equipment, offset, limit, sort)

--- a/reciperadar/models/events/base.py
+++ b/reciperadar/models/events/base.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from datetime import datetime
 from sqlalchemy import (
+    Boolean,
     Column,
     DateTime,
     String,
@@ -16,3 +17,4 @@ class BaseEvent(AbstractConcreteBase, Storable):
 
     event_id = Column(String, default=uuid4, primary_key=True)
     logged_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    suspected_bot = Column(Boolean, default=False)

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -280,7 +280,7 @@ class Recipe(Storable, Searchable):
 
         return {
             'authority': 'api',
-            'total': min(results['hits']['total']['value'], 50 * limit),
+            'total': min(results['hits']['total']['value'], 25 * limit),
             'results': recipes,
             'refinements': [refinement] if refinement else []
         }

--- a/tests/api/test_search.py
+++ b/tests/api/test_search.py
@@ -26,3 +26,19 @@ def test_search_recrawling(search, store, recrawl, client):
 
     assert response.status_code == 200
     assert recrawl.called is True
+
+
+@patch('reciperadar.api.search.recrawl_search.delay')
+@patch('reciperadar.api.search.store_event')
+@patch.object(Recipe, 'search')
+def test_bot_search(search, store, recrawl, client):
+    search.return_value = {'results': [], 'total': 0}
+
+    user_agent = (
+        'Mozilla/5.0+',
+        '(compatible; UptimeRobot/2.0; http://www.uptimerobot.com/)'
+    )
+    client.get('/api/recipes/search', headers={'user-agent': user_agent})
+
+    assert store.called
+    assert store.call_args[0][0].suspected_bot


### PR DESCRIPTION
Use the `user-agents` Python library to determine whether a user-agent string represents a possible bot, and record this in the `searches` table.

At the same time, reduce the pagination limit to 25 to reduce the scope of crawling by robots.