### PR TITLE
Add new product category for oil, vinegar & condiments

### DIFF
--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -89,6 +89,7 @@ class IngredientProduct(Storable):
             'fruit_and_veg': 'Fruit & Vegetables',
             'egg': 'Dairy',
             'meat': 'Meat',
+            'oil_and_vinegar_and_condiments': 'Oil, Vinegar & Condiments',
         }
 
         for content in self.contents:
@@ -139,6 +140,11 @@ class IngredientProduct(Storable):
             'steak': 'meat',
             'turkey': 'meat',
             'venison': 'meat',
+
+            'ketchup': 'oil_and_vinegar_and_condiments',
+            'oil': 'oil_and_vinegar_and_condiments',
+            'soy sauce': 'oil_and_vinegar_and_condiments',
+            'vinegar': 'oil_and_vinegar_and_condiments',
         }
         exclusion_graph = {
             'meat': ['stock', 'broth', 'tomato', 'bouillon', 'soup', 'eggs'],

--- a/tests/models/recipes/test_product.py
+++ b/tests/models/recipes/test_product.py
@@ -52,8 +52,8 @@ def test_chicken_exclusion_contents():
 @pytest.mark.parametrize('product,category', product_categories().items())
 def test_product_categories(product, category):
     product = IngredientProduct(
-        product=f'{product}',
-        singular=f'{product}'
+        product=product,
+        singular=product
     )
 
     assert product.category == category

--- a/tests/models/recipes/test_product.py
+++ b/tests/models/recipes/test_product.py
@@ -1,4 +1,15 @@
+import pytest
+
 from reciperadar.models.recipes import IngredientProduct
+
+
+def product_categories():
+    return {
+        'olive oil': 'Oil, Vinegar & Condiments',
+        'canola oil': 'Oil, Vinegar & Condiments',
+        'white wine vinegar': 'Oil, Vinegar & Condiments',
+        'ketchup': 'Oil, Vinegar & Condiments',
+    }
 
 
 def test_chicken_contents():
@@ -36,3 +47,13 @@ def test_chicken_exclusion_contents():
 
         # TODO: identify meat-derived products
         # assert 'meat' in contents
+
+
+@pytest.mark.parametrize('product,category', product_categories().items())
+def test_product_categories(product, category):
+    product = IngredientProduct(
+        product=f'{product}',
+        singular=f'{product}'
+    )
+
+    assert product.category == category


### PR DESCRIPTION
This change is in response to a recipe search question and is a small, iterative improvement.

Applying this change highlights two related issues:

- #1 - Knowledge of ingredient contents and categories should be extracted from the `api` and moved into a separate service
- #3 - Shopping list categories are currently communicated from the `api` to the `frontend` as human-language strings rather than resource placeholders.  This isn't internationalization-friendly and should be migrated

To aid the first issue, some test coverage is added in preparation for migrating the code.  The second item isn't huge and is worth tackling soon, but likely not the top priority at the moment.
