### PR TITLE
Add endpoint: sample recipes

### DIFF
--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -1,5 +1,7 @@
 from flask import abort, jsonify, request
 
+from sqlalchemy.sql.expression import func
+
 from reciperadar import app
 from reciperadar.models.recipes import Recipe
 from reciperadar.services.database import Database
@@ -17,6 +19,17 @@ def recipe_get(recipe_id):
         return abort(404)
 
     response = recipe.to_doc()
+    session.close()
+
+    return jsonify(response)
+
+
+@app.route('/api/recipes/sample')
+@internal
+def recipes_sample():
+    session = Database().get_session()
+    recipes = session.query(Recipe).order_by(func.random()).limit(10)
+    response = [recipe.to_doc() for recipe in recipes]
     session.close()
 
     return jsonify(response)

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -27,8 +27,10 @@ def recipe_get(recipe_id):
 @app.route('/api/recipes/sample')
 @internal
 def recipes_sample():
+    limit = request.args.get('limit', type=int, default=10)
+
     session = Database().get_session()
-    recipes = session.query(Recipe).order_by(func.random()).limit(10)
+    recipes = session.query(Recipe).order_by(func.random()).limit(limit)
     response = [recipe.to_doc() for recipe in recipes]
     session.close()
 


### PR DESCRIPTION
During development of https://github.com/openculinary/knowledge-graph/pull/4, it's useful to regularly evaluate the performance of ingredient parsing against a known dataset.  This changeset adds an API endpoint to retrieve a random sample of existing parsed recipes, which can be used for evaluation purposes.

There are risks here: there's a potential to create a noisy feedback loop by evaluating the parser against a dataset which may in future include results produced by the parser itself.  But as a bootstrapping exercise this is a useful starting point.