### PR TITLE
Use crawler url resolution endpoint

### DIFF
--- a/k8s/worker-deployment.yml
+++ b/k8s/worker-deployment.yml
@@ -32,10 +32,3 @@ spec:
               secretKeyRef:
                 name: api-verifications-mail
                 key: password
-        volumeMounts:
-        - name: proxy-cert
-          mountPath: /etc/ssl/k8s/proxy-cert
-      volumes:
-      - name: proxy-cert
-        secret:
-          secretName: proxy-cert

--- a/reciperadar/models/url.py
+++ b/reciperadar/models/url.py
@@ -76,8 +76,7 @@ class CrawlURL(BaseURL):
     def _make_request(self):
         response = requests.post(
             url='http://crawler-service/resolve',
-            data={'url': self.url},
-            proxies={}
+            data={'url': self.url}
         )
         if response.ok:
             self.resolves_to = response.json()['resolves_to']
@@ -90,6 +89,5 @@ class RecipeURL(BaseURL):
     def _make_request(self):
         return requests.post(
             url='http://crawler-service/crawl',
-            data={'url': self.url},
-            proxies={}
+            data={'url': self.url}
         )

--- a/reciperadar/models/url.py
+++ b/reciperadar/models/url.py
@@ -8,23 +8,6 @@ from tldextract import TLDExtract
 from reciperadar.models.base import Storable
 
 
-def request_patch(self, *args, **kwargs):
-    kwargs['proxies'] = kwargs.pop('proxies', {
-        'http': 'http://proxy:3128',
-        'https': 'http://proxy:3128',
-    })
-    kwargs['timeout'] = kwargs.pop('timeout', 5)
-    kwargs['verify'] = kwargs.pop('verify', '/etc/ssl/k8s/proxy-cert/ca.crt')
-    return self.request_orig(*args, **kwargs)
-
-
-setattr(
-    requests.sessions.Session, 'request_orig',
-    requests.sessions.Session.request
-)
-requests.sessions.Session.request = request_patch
-
-
 class BaseURL(AbstractConcreteBase, Storable):
     __metaclass__ = ABC
 
@@ -91,8 +74,13 @@ class CrawlURL(BaseURL):
     resolves_to = Column(String)
 
     def _make_request(self):
-        response = requests.get(url=self.url)
-        self.resolves_to = response.url
+        response = requests.post(
+            url='http://crawler-service/resolve',
+            data={'url': self.url},
+            proxies={}
+        )
+        if response.ok:
+            self.resolves_to = response.json()['resolves_to']
         return response
 
 
@@ -101,7 +89,7 @@ class RecipeURL(BaseURL):
 
     def _make_request(self):
         return requests.post(
-            url='http://crawler-service',
+            url='http://crawler-service/crawl',
             data={'url': self.url},
             proxies={}
         )

--- a/reciperadar/workers/recipes.py
+++ b/reciperadar/workers/recipes.py
@@ -78,6 +78,7 @@ def crawl_url(url):
 
     try:
         response = crawl_url.crawl()
+        url = crawl_url.resolves_to
     except RecipeURL.BackoffException:
         print(f'Backoff: {crawl_url.error_message} for url={crawl_url.url}')
         return
@@ -91,8 +92,6 @@ def crawl_url(url):
 
     if not response.ok:
         return
-
-    url = response.url
 
     session = Database().get_session()
     recipe_url = session.query(RecipeURL).get(url) or RecipeURL(url=url)

--- a/reciperadar/workers/searches.py
+++ b/reciperadar/workers/searches.py
@@ -13,8 +13,7 @@ def recrawl_search(include, exclude, equipment, offset):
     }
     response = requests.post(
         url='http://recrawler-service',
-        params=params,
-        proxies={}
+        params=params
     )
 
     try:


### PR DESCRIPTION
With https://github.com/openculinary/crawler/pull/4 merged, we can use the new URL resolution endpoint from the `crawler` service and remove related logic from the `api` service.