### PR TITLE
Merge product ancestors into contents

### DIFF
--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -30,6 +30,11 @@ class IngredientProduct(Storable):
     @staticmethod
     def from_doc(doc):
         product_id = doc.get('id') or IngredientProduct.generate_id()
+        contents = list(set(
+            [doc.get('product')] +
+            doc.get('contents', []) +
+            doc.get('ancestors', [])
+        ))
         return IngredientProduct(
             id=product_id,
             product=doc.get('product'),
@@ -38,7 +43,7 @@ class IngredientProduct(Storable):
             singular=doc.get('singular'),
             plural=doc.get('plural'),
             category=doc.get('category'),
-            contents=doc.get('contents')
+            contents=contents
         )
 
     def to_dict(self, include):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,11 @@ def raw_recipe_hit():
                 {
                     "index": 0,
                     "description": "1 unit of test ingredient one",
-                    "product": {"product": "one"}
+                    "product": {
+                        "product": "one",
+                        "contents": ["content-of-one"],
+                        "ancestors": ["ancestor-of-one"]
+                    }
                 },
                 {
                     "index": 1,

--- a/tests/models/recipes/test_recipe.py
+++ b/tests/models/recipes/test_recipe.py
@@ -7,3 +7,8 @@ def test_recipe_from_doc(raw_recipe_hit):
     assert recipe.directions[0].appliances[0].appliance == 'oven'
     assert recipe.directions[0].utensils[0].utensil == 'skewer'
     assert recipe.directions[0].vessels[0].vessel == 'casserole dish'
+
+    assert recipe.ingredients[0].product.product == 'one'
+    expected_contents = ['one', 'content-of-one', 'ancestor-of-one']
+    actual_contents = recipe.ingredients[0].product.contents
+    assert all([content in actual_contents for content in expected_contents])


### PR DESCRIPTION
With https://github.com/openculinary/knowledge-graph/pull/8 merged, we can include product ancestors in the `contents` field, which is the key field used in recipe [ingredient search](https://github.com/openculinary/api/blob/30d0fcbe57bd207cf1e6194d90d2deed0ae110d5/reciperadar/models/recipes/recipe.py#L127-L135).