### PR TITLE
Prioritize exact-matching ingredients over related-matches during recipe relevancy scoring

### DIFF
--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -293,7 +293,7 @@ class Recipe(Storable, Searchable):
         the search engine to match against the singular ingredient name in the
         index.
 
-        Recipes also content an aggregated 'contents' field, which contains all
+        Recipes also contain an aggregated 'contents' field, which contains all
         of the ingredient identifiers and also their related ingredient names.
 
         Related ingredients can include ingredient ancestors (i.e. 'tortilla'

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -170,7 +170,6 @@ class Recipe(Storable, Searchable):
             return {'script': '0', 'order': 'desc'}
 
         preamble = '''
-            def inv_score = 1 / (_score + 1);
             def product_count = doc.product_count.value;
             def found_count = 0;
             for (def bits = (long) _score; bits > 0; bits &= bits - 1) {

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -177,16 +177,17 @@ class Recipe(Storable, Searchable):
                 if (score % 10 > 2) exact_found_count++;
                 if (score % 10 > 0) found_count++;
             }
-            def missing_count = product_count - found_count;
 
-            def missing_ratio = missing_count / product_count;
+            def relevance_score = (found_count * 2 + exact_found_count);
             def normalized_rating = doc.rating.value / 10;
+            def missing_count = product_count - found_count;
+            def missing_ratio = missing_count / product_count;
         '''
         sort_configs = {
             # rank: number of ingredient matches
             # tiebreak: recipe rating
             'relevance': {
-                'script': f'{preamble} (found_count * 2 + exact_found_count) + normalized_rating',
+                'script': f'{preamble} relevance_score + normalized_rating',
                 'order': 'desc'
             },
 

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -288,10 +288,30 @@ class Recipe(Storable, Searchable):
         either singular or plural names - i.e. 'potato' or 'potatoes' may
         appear in their user interface.
 
-        When the client makes a search request however, it should always be
-        using the singular form - 'potato' in the example above.  This allows
-        the search engine to match against the singular ingredient name in the
-        index.
+        When the client makes a search request, it should always use the
+        singular ingredient name form - 'potato' in the example above.  This
+        allows the search engine to match against the corresponding singular
+        ingredient name in the recipe index.
+
+        Recipe index
+
+                            Ingredient text         Indexed ingredient name
+        recipe 1            "3 sweet potatoes"  ->  "sweet potato"
+                            "1 onion"           ->  "onion"
+                            ...
+        recipe 2            "2k onions"         ->  "onion"
+                            ...
+
+
+        End-to-end search
+
+        Autosuggest     Client query    Recipe matches  Displayed to user
+        ["onions"]  ->  ["onion"]   ->  recipe 1   ->   "3 sweet potatoes"
+                                                        "1 onion"
+                                                        ...
+                                        recipe 2   ->   "2kg onions"
+                                                        ...
+
 
         Recipes also contain an aggregated 'contents' field, which contains all
         of the ingredient identifiers and also their related ingredient names.

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -340,7 +340,8 @@ class Recipe(Storable, Searchable):
 
                                 onion   tomato  tofu        score
         recipe 1                exact   exact   partial     300 + 30 + 1 = 331
-        recipe 2                exact   no      exact       300 +  0 + 3 = 303
+        recipe 2                partial no      exact       100 +  0 + 3 = 103
+        recipe 3                exact   no      exact       300 +  0 + 3 = 303
 
         This allows the final sorting stage to determine - with some small
         possibility of error* - how many exact and inexact matches were
@@ -348,7 +349,18 @@ class Recipe(Storable, Searchable):
 
                                 score   exact_matches       all_matches
         recipe 1                331     1 + 1 + 0 = 2       1 + 1 + 1 = 3
-        recipe 2                303     1 + 0 + 1 = 2       1 + 0 + 1 = 2
+        recipe 2                103     0 + 0 + 1 = 1       1 + 0 + 1 = 2
+        recipe 3                303     1 + 0 + 1 = 2       1 + 0 + 1 = 2
+
+        At this stage we have enough information to sort the result set based
+        on the number of overall matches and to use the number of exact matches
+        as a tiebreaker within each group.
+
+        Result ranking:
+
+        - (3 matches, 2 exact) recipe 1
+        - (2 matches, 2 exact) recipe 3
+        - (2 matches, 1 exact) recipe 2
 
 
         * Inconsistent results and ranking errors can occur if an ingredient

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -177,10 +177,12 @@ class Recipe(Storable, Searchable):
                 if (score % 10 > 2) exact_found_count++;
                 if (score % 10 > 0) found_count++;
             }
+            def missing_count = product_count - found_count;
+            def exact_missing_count = product_count - exact_found_count;
 
             def relevance_score = (found_count * 2 + exact_found_count);
             def normalized_rating = doc.rating.value / 10;
-            def missing_count = product_count - found_count;
+            def missing_score = (exact_missing_count * 2 - missing_count);
             def missing_ratio = missing_count / product_count;
         '''
         sort_configs = {
@@ -194,7 +196,7 @@ class Recipe(Storable, Searchable):
             # rank: number of missing ingredients
             # tiebreak: recipe rating
             'ingredients': {
-                'script': f'{preamble} missing_count + normalized_rating',
+                'script': f'{preamble} missing_score + normalized_rating',
                 'order': 'asc'
             },
 

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -278,21 +278,24 @@ class Recipe(Storable, Searchable):
 
         * 'relevance' mode prioritizes matching as many ingredients as possible
         * 'ingredients' mode aims to find recipes with fewest extras required
-        * 'duration' mode finds recipes which can be made most quickly
+        * 'duration' mode finds recipes that can be prepared most quickly
 
         In the search index, each recipe contains a list of ingredients.
         Each ingredient is indentified by the 'ingredient.product.singular'
         field.
 
-        When users select auto-suggested ingredients, they may be shown
+        When users select auto-suggested ingredients, they may be choosing from
         either singular or plural names - i.e. 'potato' or 'potatoes' may
-        appear in their user interface.  When the client makes a search request
-        however, it should always use the singular form - 'potato' in the
-        example above.  This allows the query to match on the singular
-        ingredient name.
+        appear in their user interface.
+
+        When the client makes a search request however, it should always be
+        using the singular form - 'potato' in the example above.  This allows
+        the search engine to match against the singular ingredient name in the
+        index.
 
         Recipes also content an aggregated 'contents' field, which contains all
-        of the ingredient identifiers and also related ingredient names.
+        of the ingredient identifiers and also their related ingredient names.
+
         Related ingredients can include ingredient ancestors (i.e. 'tortilla'
         is an ancestor of 'flour tortilla').
 

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -325,6 +325,11 @@ class Recipe(Storable, Searchable):
         situation, we would prefer exact-matches on 'tofu' to appear before
         matches on 'firm tofu' which are a less precise match for the query.
 
+        In this case we can search on the 'contents' field and we will find the
+        recipe, but in order to determine whether a recipe contained an 'exact'
+        match we also need to check the 'ingredient.product.singular' field and
+        record whether the query term was present.
+
         To achieve this, we use Elasticsearch's query syntax to encode
         information about the quality of each match during search execution.
 

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -144,7 +144,7 @@ class Recipe(Storable, Searchable):
                     'constant_score': {
                         'boost': pow(10, idx) * 2,
                         'filter': {
-                            'match': {'ingredients.product.product': inc}
+                            'match': {'ingredients.product.singular': inc}
                         }
                     }
                 }

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -207,8 +207,7 @@ class Recipe(Storable, Searchable):
         }
         return sort_configs[sort]
 
-    def _render_query(self, include, exclude, equipment, sort,
-                      match_all=True, match_exact=False):
+    def _render_query(self, include, exclude, equipment, sort, match_all=True):
         include_clause = self._generate_include_clause(include)
         include_exact = self._generate_include_exact(include)
         exclude_clause = self._generate_exclude_clause(exclude)
@@ -216,7 +215,7 @@ class Recipe(Storable, Searchable):
         sort_params = self._generate_sort_params(include, sort)
 
         must = include_clause if match_all else []
-        should = include_exact if match_all and match_exact else include_clause
+        should = include_exact if match_all else include_clause
         must_not = exclude_clause
         filter = equipment_clause + [
             {'range': {'time': {'gte': 5}}},
@@ -240,16 +239,6 @@ class Recipe(Storable, Searchable):
         }, [{'_score': sort_params['order']}]
 
     def _refined_queries(self, include, exclude, equipment, sort_order):
-        if include:
-            query, sort = self._render_query(
-                include=include,
-                exclude=exclude,
-                equipment=equipment,
-                sort=sort_order,
-                match_exact=True
-            )
-            yield query, sort, None
-
         query, sort = self._render_query(
             include=include,
             exclude=exclude,


### PR DESCRIPTION
In the ingredient hierarchy, both `sweet potato` and `russet potato` share a common ancestor of `potato`.

Prior to this change, a search for `potato` would return results including any of the three ingredients mentioned and the ordering of these results would be undefined.

The changes applied here increases the ranking of exact-ingredient-matches during recipe relevance sorting -- so that recipes which list `potato` as an ingredient will appear first, for the example above -- while still retaining related-ingredient-matches in the result set.

Fixes #22 