### PR TITLE
Fixup: least-ingredients rating sort

### DIFF
--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -196,7 +196,7 @@ class Recipe(Storable, Searchable):
             # rank: number of missing ingredients
             # tiebreak: recipe rating
             'ingredients': {
-                'script': f'{preamble} missing_score + normalized_rating',
+                'script': f'{preamble} missing_score + 1 - normalized_rating',
                 'order': 'asc'
             },
 


### PR DESCRIPTION
Since fewest-extra-ingredients search uses an `asc` (ascending) score sort order, we need to _subtract_ the `normalized_rating` from the score in order to improve rankings for highly-rated recipes.

This risks reducing the score below zero; so we pre-empt this by adding a constant value of `1` before subtracting `normalized_rating`.

Fixes #24 