### PR TITLE
Hide recipes containing empty product.singular values

### DIFF
--- a/tests/models/recipes/test_recipe.py
+++ b/tests/models/recipes/test_recipe.py
@@ -12,3 +12,12 @@ def test_recipe_from_doc(raw_recipe_hit):
     expected_contents = ['one', 'content-of-one', 'ancestor-of-one']
     actual_contents = recipe.ingredients[0].product.contents
     assert all([content in actual_contents for content in expected_contents])
+
+
+def test_hidden_recipe(raw_recipe_hit):
+    recipe = Recipe().from_doc(raw_recipe_hit['_source'])
+    recipe.ingredients[0].product.singular = None
+
+    doc = recipe.to_doc()
+
+    assert doc.get('hidden') is True


### PR DESCRIPTION
Ingredients which do not have a value for the `product.singular` are essentially 'unknown' to the application.  It's worth storing these recipes in the database -- and could be convenient to query via the search engine too -- but they shouldn't be returned to users in their results.

Closes #27 