### PR TITLE
Pre-assign indexed_at timestamp before document indexing

### DIFF
--- a/reciperadar/models/base.py
+++ b/reciperadar/models/base.py
@@ -54,7 +54,7 @@ class Searchable(object):
         return self.from_doc(doc['_source'])
 
     def index(self):
-        self.es.index(index=self.noun, id=self.id, body=self.to_doc())
         if hasattr(self, 'indexed_at'):
             self.indexed_at = datetime.utcnow()
+        self.es.index(index=self.noun, id=self.id, body=self.to_doc())
         return True


### PR DESCRIPTION
It's safe (and in fact, an improvement in data consistency) to assign the `indexed_at` timestamp on documents before they are indexed into the search engine.

No data is persisted to the relational database until a subsequent [commit](https://github.com/openculinary/api/blob/3b85f998553bc3731210b97bae2612fff40147eb/reciperadar/workers/recipes.py#L18) occurs, so a failure during indexing will not result in an out-of-sync or inconsistent state.

Fixes #26 