### PR TITLE
Short-circuit sorting for empty ingredient include lists

### DIFF
--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -173,9 +173,9 @@ class Recipe(Storable, Searchable):
 
     @staticmethod
     def _generate_sort_params(include, sort):
-        # don't score relevance searches if no query ingredients are provided
-        if sort == 'relevance' and not include:
-            return {'script': '0', 'order': 'desc'}
+        # if no ingredients are specified, we may be able to short-cut sorting
+        if not include and sort != 'duration':
+            return [{'rating': {'order': 'desc'}}]
 
         preamble = '''
             def product_count = doc.product_count.value;

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -175,7 +175,7 @@ class Recipe(Storable, Searchable):
     def _generate_sort_params(include, sort):
         # if no ingredients are specified, we may be able to short-cut sorting
         if not include and sort != 'duration':
-            return [{'rating': {'order': 'desc'}}]
+            return {'script': 'doc.rating.value', 'order': 'desc'}
 
         preamble = '''
             def product_count = doc.product_count.value;


### PR DESCRIPTION
If no ingredients are specified in the `include` list, and the user has not requested search-by-preparation-time, then we can simply sort the result set based on the document `rating`. ~~bypassing the need for document script scoring~~