### PR TITLE
Improve handling of recipe URL changes

### DIFF
--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -69,7 +69,7 @@ class Recipe(Storable, Searchable):
             id=recipe_id,
             title=doc['title'],
             src=doc['src'],
-            dst=doc['dst'],
+            dst=doc.get('dst'),  # TODO: Backwards compatibility; update
             domain=doc['domain'],
             image_src=doc.get('image_src'),
             ingredients=[

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -69,6 +69,7 @@ class Recipe(Storable, Searchable):
             id=recipe_id,
             title=doc['title'],
             src=doc['src'],
+            dst=doc['dst'],
             domain=doc['domain'],
             image_src=doc.get('image_src'),
             ingredients=[

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -19,6 +19,7 @@ class Recipe(Storable, Searchable):
     id = Column(String, primary_key=True)
     title = Column(String)
     src = Column(String)
+    dst = Column(String)
     domain = Column(String)
     image_src = Column(String)
     time = Column(Integer)

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -131,6 +131,7 @@ class Recipe(Storable, Searchable):
         data['contents'] = self.contents
         data['product_count'] = len(self.products)
         data['hidden'] = self.hidden
+        data['src'] = self.dst  # TODO: Backwards compatibility; remove
         return data
 
     @staticmethod

--- a/reciperadar/models/url.py
+++ b/reciperadar/models/url.py
@@ -71,7 +71,7 @@ class BaseURL(AbstractConcreteBase, Storable):
 class CrawlURL(BaseURL):
     __tablename__ = 'crawl_urls'
 
-    resolves_to = Column(String)
+    resolves_to = Column(String, index=True)
 
     def _make_request(self):
         response = requests.post(

--- a/reciperadar/workers/recipes.py
+++ b/reciperadar/workers/recipes.py
@@ -33,6 +33,16 @@ def process_recipe(recipe_id):
     session.close()
 
 
+def find_earliest_crawl(session, url):
+    result = None
+    crawls = session.query(CrawlURL).filter_by(resolves_to=url)
+    for crawl in crawls:
+        result = result or crawl
+        result = crawl if crawl.crawled_at < result.crawled_at else result
+    if result:
+        return find_earliest_crawl(session, result.url) or result
+
+
 @celery.task(queue='crawl_recipe')
 def crawl_recipe(url):
     session = Database().get_session()
@@ -55,20 +65,25 @@ def crawl_recipe(url):
         return
 
     try:
-        recipe = Recipe.from_doc(response.json())
+        recipe_data = response.json()
     except Exception as e:
         print(f'Failed to load crawler result for url={url} - {e}')
         return
 
-    recipe_id = recipe.id
-
     session = Database().get_session()
-    session.query(Recipe).filter_by(id=recipe_id).delete()
+
+    # Store recipe with first-known URL as source and latest URL as destination
+    earliest_crawl = find_earliest_crawl(session, url)
+    recipe_data['src'] = earliest_crawl.url
+    recipe_data['dst'] = url
+    recipe = Recipe.from_doc(recipe_data)
+
+    session.query(Recipe).filter_by(id=recipe.id).delete()
     session.add(recipe)
     session.commit()
-    session.close()
 
-    process_recipe.delay(recipe_id)
+    process_recipe.delay(recipe.id)
+    session.close()
 
 
 @celery.task(queue='crawl_url')

--- a/reciperadar/workers/recipes.py
+++ b/reciperadar/workers/recipes.py
@@ -39,7 +39,10 @@ def find_earliest_crawl(session, url):
     for crawl in crawls:
         if crawl.url == url:
             continue
+        if not crawl.crawled_at:
+            continue
         result = result or crawl
+        result = crawl if not result.crawled_at else result
         result = crawl if crawl.crawled_at < result.crawled_at else result
     if result:
         return find_earliest_crawl(session, result.url) or result

--- a/reciperadar/workers/recipes.py
+++ b/reciperadar/workers/recipes.py
@@ -37,6 +37,8 @@ def find_earliest_crawl(session, url):
     result = None
     crawls = session.query(CrawlURL).filter_by(resolves_to=url)
     for crawl in crawls:
+        if crawl.url == url:
+            continue
         result = result or crawl
         result = crawl if crawl.crawled_at < result.crawled_at else result
     if result:


### PR DESCRIPTION
During crawling of new recipes, determine the recipe `src` and `dst` (new) based on the first-known and current URLs for the recipe, respectively.

Fixes #31 