### PR TITLE
Ingredient Autosuggest: include product.category field in response

### DIFF
--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -121,6 +121,13 @@ class RecipeIngredient(Storable, Searchable):
                               }
                             }
                           }
+                        },
+                        # retrieve a category for each ingredient
+                        'category': {
+                          'terms': {
+                            'field': 'ingredients.product.category',
+                            'size': 1
+                          }
                         }
                       }
                     }
@@ -143,9 +150,11 @@ class RecipeIngredient(Storable, Searchable):
             plural_docs = result['plurality']['plural']['buckets']
             plural_wins = plural_count > total_count - plural_count
 
+            category_docs = result['category']['buckets']
             suggestion_doc = plural_docs[0] if plural_wins else result
             suggestions.append(IngredientProduct(
                 product=suggestion_doc['key'],
+                category=category_docs[0]['key'] if category_docs else None,
                 singular=result['key']
             ))
 

--- a/scripts/update-recipe-index.py
+++ b/scripts/update-recipe-index.py
@@ -29,6 +29,7 @@ mapping = {
                 'product': {
                     'properties': {
                         'product': {'type': 'keyword'},
+                        'category': {'type': 'keyword'},
                         'is_plural': {'type': 'boolean'},
                         'singular': {'type': 'keyword'},
                         'plural': {'type': 'keyword'},


### PR DESCRIPTION
In order to allow users to manually add ingredients one-at-a-time to their shopping list *and* also have them correctly categorized at add-time, the application needs to know which category each ingredient belongs to.

This changeset includes the ingredient's product category in the response so that the application can place the ingredient into the appropriate grouping.

Fixes #17 