### PR TITLE
Relocate determination of default sort order

### DIFF
--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -38,6 +38,9 @@ def recipes():
     limit = min(request.args.get('limit', type=int, default=10), 10)
     sort = request.args.get('sort', default='ingredients')
 
+    if sort and sort not in RecipeSearch.sort_methods():
+        return abort(400)
+
     results = RecipeSearch().query(
         include=include,
         exclude=exclude,

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -47,7 +47,7 @@ def recipes():
         equipment=equipment,
         offset=offset,
         limit=limit,
-        sort_order=sort
+        sort=sort
     )
 
     user_agent = request.headers.get('user-agent')

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -36,7 +36,7 @@ def recipes():
     equipment = request.args.getlist('equipment[]')
     offset = min(request.args.get('offset', type=int, default=0), (25*10)-10)
     limit = min(request.args.get('limit', type=int, default=10), 10)
-    sort = request.args.get('sort', default='ingredients')
+    sort = request.args.get('sort', type=str)
 
     if sort and sort not in RecipeSearch.sort_methods():
         return abort(400)

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -44,11 +44,7 @@ class RecipeSearch(QueryRepository):
         ]
 
     @staticmethod
-    def _generate_sort_params(include, sort):
-        # if no ingredients are specified, we may be able to short-cut sorting
-        if not include and sort != 'duration':
-            return {'script': 'doc.rating.value', 'order': 'desc'}
-
+    def sort_methods():
         preamble = '''
             def product_count = doc.product_count.value;
             def exact_found_count = 0;
@@ -65,7 +61,7 @@ class RecipeSearch(QueryRepository):
             def missing_score = (exact_missing_count * 2 - missing_count);
             def missing_ratio = missing_count / product_count;
         '''
-        sort_configs = {
+        return {
             # rank: number of ingredient matches
             # tiebreak: recipe rating
             'relevance': {
@@ -87,7 +83,12 @@ class RecipeSearch(QueryRepository):
                 'order': 'asc'
             },
         }
-        return sort_configs[sort]
+
+    def _generate_sort_params(self, include, sort):
+        # if no ingredients are specified, we may be able to short-cut sorting
+        if not include and sort != 'duration':
+            return {'script': 'doc.rating.value', 'order': 'desc'}
+        return self.sort_methods[sort]
 
     def _render_query(self, include, exclude, equipment, sort, match_all=True):
         include_clause = self._generate_include_clause(include)

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -85,6 +85,9 @@ class RecipeSearch(QueryRepository):
         }
 
     def _generate_sort_params(self, include, sort):
+        # set the default sort order
+        if not sort:
+            sort = 'ingredients'
         # if no ingredients are specified, we may be able to short-cut sorting
         if not include and sort != 'duration':
             return {'script': 'doc.rating.value', 'order': 'desc'}

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -84,8 +84,8 @@ class RecipeSearch(QueryRepository):
             },
         }
 
-    def _generate_sort_params(self, include, sort):
-        # set the default sort order
+    def _generate_sort_method(self, include, sort):
+        # set the default sort method
         if not sort:
             sort = 'ingredients'
         # if no ingredients are specified, we may be able to short-cut sorting
@@ -98,7 +98,7 @@ class RecipeSearch(QueryRepository):
         include_exact = self._generate_include_exact(include)
         exclude_clause = self._generate_exclude_clause(exclude)
         equipment_clause = self._generate_equipment_clause(equipment)
-        sort_params = self._generate_sort_params(include, sort)
+        sort_params = self._generate_sort_method(include, sort)
 
         must = include_clause if match_all else []
         should = include_exact if match_all else include_clause
@@ -126,39 +126,39 @@ class RecipeSearch(QueryRepository):
             }
         }, [{'_score': sort_params['order']}]
 
-    def _refined_queries(self, include, exclude, equipment, sort_order):
-        query, sort = self._render_query(
+    def _refined_queries(self, include, exclude, equipment, sort):
+        query, sort_method = self._render_query(
             include=include,
             exclude=exclude,
             equipment=equipment,
-            sort=sort_order
+            sort=sort
         )
-        yield query, sort, None
+        yield query, sort_method, None
 
         item_count = len(include)
         if item_count > 3:
             for _ in range(item_count):
                 removed = include.pop(0)
-                query, sort = self._render_query(
+                query, sort_method = self._render_query(
                     include=include,
                     exclude=exclude,
                     equipment=equipment,
-                    sort=sort_order
+                    sort=sort
                 )
-                yield query, sort, f'removed:{removed}'
+                yield query, sort_method, f'removed:{removed}'
                 include.append(removed)
 
         if item_count > 1:
-            query, sort = self._render_query(
+            query, sort_method = self._render_query(
                 include=include,
                 exclude=exclude,
                 equipment=equipment,
-                sort=sort_order,
+                sort=sort,
                 match_all=False
             )
-            yield query, sort, 'match_any'
+            yield query, sort_method, 'match_any'
 
-    def query(self, include, exclude, equipment, offset, limit, sort_order):
+    def query(self, include, exclude, equipment, offset, limit, sort):
         """
         Searching for recipes is currently supported in three different modes:
 
@@ -283,16 +283,16 @@ class RecipeSearch(QueryRepository):
             include=include,
             exclude=exclude,
             equipment=equipment,
-            sort_order=sort_order
+            sort=sort
         )
-        for query, sort, refinement in queries:
+        for query, sort_method, refinement in queries:
             results = self.es.search(
                 index='recipes',
                 body={
                     'from': offset,
                     'size': limit,
                     'query': query,
-                    'sort': sort,
+                    'sort': sort_method,
                 }
             )
             if results['hits']['total']['value']:

--- a/tests/api/test_recipes.py
+++ b/tests/api/test_recipes.py
@@ -3,6 +3,17 @@ from mock import patch
 from reciperadar.search.recipes import RecipeSearch
 
 
+@patch.object(RecipeSearch, 'query')
+def test_search_invalid_sort(query, client):
+    response = client.get(
+        path='/api/recipes/search',
+        query_string={'sort': 'invalid'}
+    )
+
+    assert response.status_code == 400
+    assert not query.called
+
+
 @patch('werkzeug.datastructures.Headers.get')
 @patch('reciperadar.api.recipes.recrawl_search.delay')
 @patch('reciperadar.api.recipes.store_event')


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The core search engine in RecipeRadar is responsible for evaluating the user's query intent and returning relevant results.

Sometimes that requires knowing exactly what the user did and did not specify in their query.

Currently the `/api/recipes/search` endpoint sets a default value for the `sort` parameter if one is not provided in the request.

This default-sort-method determination should move from the API endpoint into the search code.

### Briefly summarize the changes
1. Add validation on the requested `sort` method
1. Move the default `sort` method determination from the API into the core search code
1. Perform some minor variable naming cleanup

### How have the changes been tested?
1. Unit testing
