### PR TITLE
Empty query hint

### DIFF
--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -133,7 +133,7 @@ class RecipeSearch(QueryRepository):
                 include=include,
                 exclude=exclude,
                 equipment=equipment,
-                sort=sort_order
+                sort=sort
             )
             yield query, sort_method, 'empty_query'
             return

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -128,7 +128,7 @@ class RecipeSearch(QueryRepository):
 
     def _refined_queries(self, include, exclude, equipment, sort):
         # Provide an 'empty query' hint
-        if not include and not exclude and not equipment:
+        if not include and not exclude and not equipment and not sort:
             query, sort_method = self._render_query(
                 include=include,
                 exclude=exclude,

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -128,7 +128,7 @@ class RecipeSearch(QueryRepository):
 
     def _refined_queries(self, include, exclude, equipment, sort):
         # Provide an 'empty query' hint
-        if not include and not exclude and not equipment and not sort:
+        if not any([include, exclude, equipment, sort]):
             query, sort_method = self._render_query(
                 include=include,
                 exclude=exclude,

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -123,6 +123,17 @@ class RecipeSearch(QueryRepository):
         }, [{'_score': sort_params['order']}]
 
     def _refined_queries(self, include, exclude, equipment, sort_order):
+        # Provide an 'empty query' hint
+        if not include and not exclude and not equipment:
+            query, sort = self._render_query(
+                include=include,
+                exclude=exclude,
+                equipment=equipment,
+                sort=sort_order
+            )
+            yield sort, sort, 'empty_query'
+            return
+
         query, sort = self._render_query(
             include=include,
             exclude=exclude,

--- a/tests/api/test_recipes.py
+++ b/tests/api/test_recipes.py
@@ -14,6 +14,19 @@ def test_search_invalid_sort(query, client):
     assert not query.called
 
 
+@patch('reciperadar.api.recipes.recrawl_search.delay')
+@patch('reciperadar.api.recipes.store_event')
+@patch('reciperadar.search.base.QueryRepository.es.search')
+def test_search_empty_query(search, store, recrawl, client):
+    search.return_value = {'hits': {'hits': [], 'total': {'value': 0}}}
+
+    response = client.get('/api/recipes/search')
+
+    assert response.status_code == 200
+    assert 'refinements' in response.json
+    assert 'empty_query' in response.json['refinements']
+
+
 @patch('werkzeug.datastructures.Headers.get')
 @patch('reciperadar.api.recipes.recrawl_search.delay')
 @patch('reciperadar.api.recipes.store_event')


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Users may perform searches without providing any query parameters, and we can cater to that type of query.

It's possible that those users didn't intend to make a 'empty' queries, so we can offer them a  message to inform them of the situation and provide possible guidance.

### Briefly summarize the changes
1. Respond with an `empty_query` refinement when no query details are provided

### How have the changes been tested?
1. Unit test coverage
