### PR TITLE
Refactor earliest crawl retrieval

### DIFF
--- a/reciperadar/workers/recipes.py
+++ b/reciperadar/workers/recipes.py
@@ -36,7 +36,7 @@ def process_recipe(recipe_id):
 def find_earliest_crawl(session, url):
     return session.query(CrawlURL) \
         .filter_by(resolves_to=url) \
-        .filter(CrawlURL.crawled_at.is_not(None)) \
+        .filter(CrawlURL.crawled_at.isnot(None)) \
         .order_by(CrawlURL.crawled_at.asc()) \
         .one()
 

--- a/reciperadar/workers/recipes.py
+++ b/reciperadar/workers/recipes.py
@@ -37,8 +37,6 @@ def find_earliest_crawl(session, url):
     result = None
     crawls = session.query(CrawlURL).filter_by(resolves_to=url)
     for crawl in crawls:
-        if crawl.url == url:
-            continue
         if not crawl.crawled_at:
             continue
         result = result or crawl

--- a/reciperadar/workers/recipes.py
+++ b/reciperadar/workers/recipes.py
@@ -34,16 +34,11 @@ def process_recipe(recipe_id):
 
 
 def find_earliest_crawl(session, url):
-    result = None
-    crawls = session.query(CrawlURL).filter_by(resolves_to=url)
-    for crawl in crawls:
-        if not crawl.crawled_at:
-            continue
-        result = result or crawl
-        result = crawl if not result.crawled_at else result
-        result = crawl if crawl.crawled_at < result.crawled_at else result
-    if result:
-        return find_earliest_crawl(session, result.url) or result
+    return session.query(CrawlURL) \
+        .filter_by(resolves_to=url) \
+        .filter(CrawlURL.crawled_at.is_not(None)) \
+        .order_by(CrawlURL.crawled_at.asc()) \
+        .one()
 
 
 @celery.task(queue='crawl_recipe')


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
There was a slightly-broken recursive implementation of a domain-specific sorting algorithm within the `find_earliest_crawl` method.

This was implemented because it was seen as being quicker and safer to implement at the time than more thoroughly reading the `sqlalchemy` documentation to determine how to sort and query safely and efficiently.  In particular there was a question about whether conditions inside the `filter` method can utilize database indexes.

This change uses the `filter` method for first-pass querying, and then applies `filter_by` for expressions which may or may not be pushed to the database engine for evaluation.

The `order_by` statement is introduced to handle sorting in a safer and more standard manner.

### Briefly summarize the changes
1. Rewrite `find_earliest_crawl` using a [sqlalchemy](https://www.sqlalchemy.org/) query

### How have the changes been tested?
1. Locally via a development instance of the service

**List any issues that this change relates to**
Fixes #43 