### PR TITLE
Store additional ingredient and product metadata

### DIFF
--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -20,6 +20,7 @@ class RecipeIngredient(Storable, Searchable):
     id = Column(String, primary_key=True)
     index = Column(Integer)
     description = Column(String)
+    markup = Column(String)
     product = relationship(
         'IngredientProduct',
         backref='recipe_ingredient',
@@ -40,6 +41,7 @@ class RecipeIngredient(Storable, Searchable):
             id=ingredient_id,
             index=doc.get('index'),  # TODO
             description=doc['description'].strip(),
+            markup=doc.get('markup'),
             product=IngredientProduct.from_doc(doc['product']),
             quantity=doc.get('quantity'),
             quantity_parser=doc.get('quantity_parser'),
@@ -69,7 +71,10 @@ class RecipeIngredient(Storable, Searchable):
                 'value': ' ',
             })
         tokens.append(self.product.to_dict(include))
-        return {'tokens': tokens}
+        return {
+            'markup': self.markup,
+            'tokens': tokens,
+        }
 
     def to_doc(self):
         data = super().to_doc()

--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -16,6 +16,7 @@ class IngredientProduct(Storable):
     ingredient_id = Column(String, fk, index=True)
 
     id = Column(String, primary_key=True)
+    product_id = Column(String)
     product = Column(String)
     product_parser = Column(String)
     is_plural = Column(Boolean)
@@ -37,6 +38,7 @@ class IngredientProduct(Storable):
         ))
         return IngredientProduct(
             id=product_id,
+            product_id=doc.get('product_id'),
             product=doc.get('product'),
             product_parser=doc.get('product_parser'),
             is_plural=doc.get('is_plural'),


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Now that ingredient description markup is available in responses from the `crawler` service, and the `knowledge-graph` product ID is returned, we can store these fields in the database.

### Briefly summarize the changes
1. Store ingredient `markup` against `RecipeIngredient` rows
1. Store product `product_id` against `IngredientProduct` rows

### How have the changes been tested?
1. Manual inspection
1. One-off crawl of a recipe into the production database from this branch

**List any issues that this change relates to**
Relates to https://github.com/openculinary/knowledge-graph/pull/27
Relates to https://github.com/openculinary/knowledge-graph/pull/33
Relates to https://github.com/openculinary/knowledge-graph/pull/35
Relates to https://github.com/openculinary/ingredient-parser/pull/17
Relates to https://github.com/openculinary/ingredient-parser/pull/18