### PR TITLE
Include ingredient state in search API responses

### DIFF
--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -73,6 +73,7 @@ class RecipeIngredient(Storable, Searchable):
         tokens.append(self.product.to_dict(include))
         return {
             'markup': self.markup,
+            'state': self.product.state(include),
             'tokens': tokens,
         }
 

--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -48,18 +48,20 @@ class IngredientProduct(Storable):
             contents=contents
         )
 
-    def to_dict(self, include):
+    def state(self, include):
         states = {
             True: IngredientProduct.STATE_AVAILABLE,
             False: IngredientProduct.STATE_REQUIRED,
         }
         available = bool(set(self.contents or []) & set(include or []))
+        return states[available]
 
+    def to_dict(self, include):
         return {
             'type': 'product',
             'value': self.product,
             'category': self.category,
             'singular': self.singular,
             'plural': self.plural,
-            'state': states[available]
+            'state': self.state(include),
         }


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Include a `state` response field to indicate whether each ingredient is available.

NB: This property/function should be moved up to `RecipeIngredient` from `IngredientProduct`.

### How have the changes been tested?
1. Local testing via a development instance of the service