### PR TITLE
Rename feedback account

### DIFF
--- a/k8s/scripts/create-secrets.sh
+++ b/k8s/scripts/create-secrets.sh
@@ -4,7 +4,7 @@ read username
 echo "Please provide the mail account password"
 read -s password
 
-kubectl delete secret api-verifications-mail
-kubectl create secret generic api-verifications-mail \
+kubectl delete secret api-contact-mail
+kubectl create secret generic api-contact-mail \
   --from-literal=username=${username} \
   --from-literal=password=${password}

--- a/k8s/web-deployment.yaml
+++ b/k8s/web-deployment.yaml
@@ -25,10 +25,10 @@ spec:
           - name: MAIL_USERNAME
             valueFrom:
               secretKeyRef:
-                name: api-verifications-mail
+                name: api-contact-mail
                 key: username
           - name: MAIL_PASSWORD
             valueFrom:
               secretKeyRef:
-                name: api-verifications-mail
+                name: api-contact-mail
                 key: password

--- a/k8s/worker-deployment.yaml
+++ b/k8s/worker-deployment.yaml
@@ -21,14 +21,3 @@ spec:
         name: api
         command: ['pipenv']
         args: ['run', 'celery', 'worker', '-A', 'reciperadar.workers', '-Q', 'celery,crawl_url,crawl_recipe,process_recipe,index_recipe,recrawl_search']
-        env:
-          - name: MAIL_USERNAME
-            valueFrom:
-              secretKeyRef:
-                name: api-verifications-mail
-                key: username
-          - name: MAIL_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: api-verifications-mail
-                key: password

--- a/reciperadar/models/feedback.py
+++ b/reciperadar/models/feedback.py
@@ -27,7 +27,7 @@ class Feedback(Storable):
 
             message = Message(
                 subject=f'User feedback: {title}',
-                sender='verifications@reciperadar.com',
+                sender='contact@reciperadar.com',
                 recipients=['feedback@reciperadar.com'],
                 html=html
             )


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The RecipeRadar service doesn't currently send verification emails, and it would be useful to have a more generic 'contact' email address for the service.

### Briefly summarize the changes
1. Migrate the `verifications` account to an updated name, `contact`

### How have the changes been tested?
1. A test email has been issued via the updated account