### PR TITLE
Store additional direction metadata

### DIFF
--- a/reciperadar/models/recipes/direction.py
+++ b/reciperadar/models/recipes/direction.py
@@ -21,6 +21,7 @@ class RecipeDirection(Storable):
     id = Column(String, primary_key=True)
     index = Column(Integer)
     description = Column(String)
+    markup = Column(String)
     appliances = relationship(
         'DirectionAppliance',
         backref='recipe_directions',
@@ -44,6 +45,7 @@ class RecipeDirection(Storable):
             id=direction_id,
             index=doc.get('index'),  # TODO
             description=doc['description'],
+            markup=doc.get('markup'),
             appliances=[
                 DirectionAppliance.from_doc(appliance)
                 for appliance in doc.get('appliances', [])
@@ -73,7 +75,10 @@ class RecipeDirection(Storable):
         return data
 
     def to_dict(self):
-        return {'tokens': [{
-            'type': 'text',
-            'value': self.description
-        }]}
+        return {
+            'markup': self.markup,
+            'tokens': [{
+                'type': 'text',
+                'value': self.description,
+            }],
+        }


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Now that direction description markup is available in responses from the `crawler` service, we can store the markup in the database.

### Briefly summarize the changes
1. Store direction `markup` against `RecipeDirection` rows

### How have the changes been tested?
1. Manual inspection

**List any issues that this change relates to**
Relates to https://github.com/openculinary/api/pull/49