### PR TITLE
Search API: Include product metadata in ingredient response

### DIFF
--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -73,6 +73,7 @@ class RecipeIngredient(Storable, Searchable):
         tokens.append(self.product.to_dict(include))
         return {
             'markup': self.markup,
+            'product': self.product.to_dict(include),
             'state': self.product.state(include),
             'tokens': tokens,
         }

--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -60,6 +60,7 @@ class IngredientProduct(Storable):
         return {
             'type': 'product',
             'id': self.product_id,
+            'product': self.product,
             'value': self.product,
             'category': self.category,
             'singular': self.singular,

--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -59,6 +59,7 @@ class IngredientProduct(Storable):
     def to_dict(self, include):
         return {
             'type': 'product',
+            'id': self.product_id,
             'value': self.product,
             'category': self.category,
             'singular': self.singular,


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This change adds support for product metadata directly on the search API `ingredient` response object, to support openculinary/frontend#133
