### PR TITLE
Cleanup: remove 'tokens' fields from Search API response

### DIFF
--- a/reciperadar/models/recipes/direction.py
+++ b/reciperadar/models/recipes/direction.py
@@ -77,8 +77,4 @@ class RecipeDirection(Storable):
     def to_dict(self):
         return {
             'markup': self.markup,
-            'tokens': [{
-                'type': 'text',
-                'value': self.description,
-            }],
         }

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -51,31 +51,9 @@ class RecipeIngredient(Storable, Searchable):
         )
 
     def to_dict(self, include=None):
-        tokens = []
-        if self.quantity:
-            tokens.append({
-                'type': 'quantity',
-                'value': self.quantity,
-            })
-            tokens.append({
-                'type': 'text',
-                'value': ' ',
-            })
-        if self.units:
-            tokens.append({
-                'type': 'units',
-                'value': self.units,
-            })
-            tokens.append({
-                'type': 'text',
-                'value': ' ',
-            })
-        tokens.append(self.product.to_dict(include))
         return {
             'markup': self.markup,
             'product': self.product.to_dict(include),
-            'state': self.product.state(include),
-            'tokens': tokens,
         }
 
     def to_doc(self):


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
With openculinary/frontend#133 deployed, we can begin considering removal of the `tokens` fields from Search API responses entirely.

Note that existing frontend application clients may exist that still rely on the presence of these fields.