### PR TITLE
Autosuggest: use product_id as aggregation key

### DIFF
--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -85,9 +85,9 @@ class RecipeIngredient(Storable, Searchable):
                   },
                   'aggregations': {
                     # retrieve the top products in singular pluralization
-                    'product': {
+                    'product_id': {
                       'terms': {
-                        'field': 'ingredients.product.singular',
+                        'field': 'ingredients.product.product_id',
                         'min_doc_count': 5,
                         'size': 10
                       },
@@ -126,7 +126,7 @@ class RecipeIngredient(Storable, Searchable):
           }
         }
         results = self.es.search(index=self.noun, body=query)['aggregations']
-        results = results['ingredients']['products']['product']['buckets']
+        results = results['ingredients']['products']['product_id']['buckets']
 
         # iterate through the suggestions and determine whether to display
         # the singular or plural form of the word based on how frequently

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -156,6 +156,7 @@ class RecipeIngredient(Storable, Searchable):
                 product=suggestion_doc['key'],
                 category=category,
                 singular=singular,
+                plural=plural,
             ))
 
         suggestions.sort(key=lambda s: (
@@ -166,5 +167,6 @@ class RecipeIngredient(Storable, Searchable):
         return [{
             'product': suggestion.product,
             'category': suggestion.category,
-            'singular': suggestion.singular
+            'singular': suggestion.singular,
+            'plural': suggestion.plural,
         } for suggestion in suggestions]

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -151,9 +151,8 @@ class RecipeIngredient(Storable, Searchable):
             singular = (result['singular']['buckets'] or [{}])[0].get('key')
             plural = (result['plural']['buckets'] or [{}])[0].get('key')
 
-            suggestion_doc = plural_docs[0] if plural_wins else result
             suggestions.append(IngredientProduct(
-                product=suggestion_doc['key'],
+                product=plural if plural_wins else singular,
                 category=category,
                 singular=singular,
                 plural=plural,

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -147,15 +147,15 @@ class RecipeIngredient(Storable, Searchable):
             plural_docs = result['plurality']['plural']['buckets']
             plural_wins = plural_count > total_count - plural_count
 
-            category_docs = result['category']['buckets']
-            singular_docs = result['singular']['buckets']
-            plural_docs = result['plural']['buckets']
+            category = (result['category']['buckets'] or [{}])[0].get('key')
+            singular = (result['singular']['buckets'] or [{}])[0].get('key')
+            plural = (result['plural']['buckets'] or [{}])[0].get('key')
 
             suggestion_doc = plural_docs[0] if plural_wins else result
             suggestions.append(IngredientProduct(
                 product=suggestion_doc['key'],
-                category=category_docs[0]['key'] if category_docs else None,
-                singular=singular_docs[0]['key'] if singular_docs else None,
+                category=category,
+                singular=singular,
             ))
 
         suggestions.sort(key=lambda s: (

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -137,11 +137,13 @@ class RecipeIngredient(Storable, Searchable):
             plural_count = result['plurality']['doc_count']
             plural_wins = plural_count > total_count - plural_count
 
+            product_id = result['key']
             category = (result['category']['buckets'] or [{}])[0].get('key')
             singular = (result['singular']['buckets'] or [{}])[0].get('key')
             plural = (result['plural']['buckets'] or [{}])[0].get('key')
 
             suggestions.append(IngredientProduct(
+                product_id=product_id,
                 product=plural if plural_wins else singular,
                 category=category,
                 singular=singular,
@@ -154,6 +156,7 @@ class RecipeIngredient(Storable, Searchable):
             len(s.product)),  # sort remaining matches by length
         )
         return [{
+            'product_id': suggestion.product_id,
             'product': suggestion.product,
             'category': suggestion.category,
             'singular': suggestion.singular,

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -96,15 +96,6 @@ class RecipeIngredient(Storable, Searchable):
                         'plurality': {
                           'filter': {
                             'match': {'ingredients.product.is_plural': True}
-                          },
-                          'aggregations': {
-                            # return the plural word form in the results
-                            'plural': {
-                              'terms': {
-                                'field': 'ingredients.product.plural',
-                                'size': 1
-                              }
-                            }
                           }
                         },
                         # retrieve a category for each ingredient
@@ -144,7 +135,6 @@ class RecipeIngredient(Storable, Searchable):
         for result in results:
             total_count = result['doc_count']
             plural_count = result['plurality']['doc_count']
-            plural_docs = result['plurality']['plural']['buckets']
             plural_wins = plural_count > total_count - plural_count
 
             category = (result['category']['buckets'] or [{}])[0].get('key')

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -148,11 +148,14 @@ class RecipeIngredient(Storable, Searchable):
             plural_wins = plural_count > total_count - plural_count
 
             category_docs = result['category']['buckets']
+            singular_docs = result['singular']['buckets']
+            plural_docs = result['plural']['buckets']
+
             suggestion_doc = plural_docs[0] if plural_wins else result
             suggestions.append(IngredientProduct(
                 product=suggestion_doc['key'],
                 category=category_docs[0]['key'] if category_docs else None,
-                singular=result['key']
+                singular=singular_docs[0]['key'] if singular_docs else None,
             ))
 
         suggestions.sort(key=lambda s: (

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -113,6 +113,18 @@ class RecipeIngredient(Storable, Searchable):
                             'field': 'ingredients.product.category',
                             'size': 1
                           }
+                        },
+                        'singular': {
+                          'terms': {
+                            'field': 'ingredients.product.singular',
+                            'size': 1
+                          }
+                        },
+                        'plural': {
+                          'terms': {
+                            'field': 'ingredients.product.plural',
+                            'size': 1
+                          }
                         }
                       }
                     }


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The ingredient autosuggestion results display product names as singular-or-plural depending on what appears more often in the source recipe text.  This is something we're hoping to [write more about](https://github.com/openculinary/blog/issues/2) in future.

Currently the Elasticsearch query code is using the singularized form of the product name as an aggregation key.  This is fine and generally works, but now that we have a `product_id` key field that uniquely identifies a product, we should use this field as the aggregation key instead.

### Briefly summarize the changes
1. Switch from `product.singular` to `product.product_id` as aggregation key during ingredient autosuggestion
1. Include the `product.product_id` in the results returned to the caller
