### PR TITLE
Indexing: enable tokenization of product name field

### DIFF
--- a/scripts/update-recipe-index.py
+++ b/scripts/update-recipe-index.py
@@ -29,7 +29,7 @@ mapping = {
                 'product': {
                     'properties': {
                         'product_id': {'type': 'keyword'},
-                        'product': {'type': 'keyword'},
+                        'product': {'type': 'text'},
                         'category': {'type': 'keyword'},
                         'is_plural': {'type': 'boolean'},
                         'singular': {'type': 'keyword'},


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
As reported in openculinary/frontend#90, it can be useful for ingredient suggestions to include products that _partially_ match the entered text, instead of requiring a strict prefix match.

For example, when searching for 'garlic', it would be useful for 'roasted garlic' to appear in the list of suggested ingredients.

This can be solved by splitting the product names into individual word tokens so that the [product prefix and match](https://github.com/openculinary/api/blob/94e003400afa3e24976827a68f625807245bfde2/reciperadar/models/recipes/ingredient.py#L80-L83) logic applies to any of the component tokens.

Elasticsearch provides untokenized indexing when using the [`keyword` field datatype](https://www.elastic.co/guide/en/elasticsearch/reference/7.7/keyword.html) and tokenized behaviour when using the [`text` field datatype](https://www.elastic.co/guide/en/elasticsearch/reference/7.7/text.html).

### Briefly summarize the changes
1. Allow each recipe ingredient name to be split into multiple tokens during indexing (`roasted garlic` -> `['roasted', 'garlic']` instead of `['roasted garlic']`)

### How have the changes been tested?
1. Indexing and search changes can be tricky to test; this change has been applied to the production search environment

**List any issues that this change relates to**
Fixes openculinary/frontend#90
