### PR TITLE
Refactor: write log events asynchronously via celery queue 

### DIFF
--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -60,8 +60,8 @@ def recipe_search():
     # Perform a recrawl for the search to find any new/missing recipes
     recrawl_search.delay(include, exclude, equipment, offset)
 
-    # TODO: Once 'event' is json serializable: switch to store_event.delay
-    store_event(SearchEvent(
+    # Log a search event
+    search_event = SearchEvent(
         suspected_bot=suspected_bot,
         include=include,
         exclude=exclude,
@@ -71,7 +71,11 @@ def recipe_search():
         sort=sort,
         results_ids=[result['id'] for result in results['results']],
         results_total=results['total']
-    ))
+    )
+    store_event.delay(
+        event_table=search_event.__tablename__,
+        event_data=search_event.to_doc()
+    )
 
     return jsonify(results)
 

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -2,7 +2,6 @@ from flask import abort, jsonify, request
 from user_agents import parse as ua_parser
 
 from reciperadar import app
-from reciperadar.models.events.search import SearchEvent
 from reciperadar.models.recipes import Recipe
 from reciperadar.search.recipes import RecipeSearch
 from reciperadar.utils.decorators import internal
@@ -61,20 +60,19 @@ def recipe_search():
     recrawl_search.delay(include, exclude, equipment, offset)
 
     # Log a search event
-    search_event = SearchEvent(
-        suspected_bot=suspected_bot,
-        include=include,
-        exclude=exclude,
-        equipment=equipment,
-        offset=offset,
-        limit=limit,
-        sort=sort,
-        results_ids=[result['id'] for result in results['results']],
-        results_total=results['total']
-    )
     store_event.delay(
-        event_table=search_event.__tablename__,
-        event_data=search_event.to_doc()
+        event_table='searches',
+        event_data={
+            'suspected_bot': suspected_bot,
+            'include': include,
+            'exclude': exclude,
+            'equipment': equipment,
+            'offset': offset,
+            'limit': limit,
+            'sort': sort,
+            'results_ids': [result['id'] for result in results['results']],
+            'results_total': results['total']
+        }
     )
 
     return jsonify(results)

--- a/reciperadar/api/redirect.py
+++ b/reciperadar/api/redirect.py
@@ -1,7 +1,6 @@
 from flask import abort, redirect
 
 from reciperadar import app
-from reciperadar.models.events.redirect import RedirectEvent
 from reciperadar.models.recipes import Recipe
 from reciperadar.workers.events import store_event
 
@@ -12,14 +11,13 @@ def recipe_redirect(recipe_id):
     if not recipe:
         return abort(404)
 
-    redirect_event = RedirectEvent(
-        recipe_id=recipe.id,
-        domain=recipe.domain,
-        src=recipe.src
-    )
     store_event.delay(
-        event_table=redirect_event.__tablename__,
-        event_data=redirect_event.to_doc()
+        event_table='redirects',
+        event_data={
+            'recipe_id': recipe.id,
+            'domain': recipe.domain,
+            'src': recipe.src,
+        }
     )
 
     return redirect(recipe.src, code=301)

--- a/reciperadar/api/redirect.py
+++ b/reciperadar/api/redirect.py
@@ -12,10 +12,14 @@ def recipe_redirect(recipe_id):
     if not recipe:
         return abort(404)
 
-    store_event(RedirectEvent(
+    redirect_event = RedirectEvent(
         recipe_id=recipe.id,
         domain=recipe.domain,
         src=recipe.src
-    ))
+    )
+    store_event.delay(
+        event_table=redirect_event.__tablename__,
+        event_data=redirect_event.to_doc()
+    )
 
     return redirect(recipe.src, code=301)

--- a/reciperadar/workers/events.py
+++ b/reciperadar/workers/events.py
@@ -1,9 +1,21 @@
+from reciperadar.models.events.redirect import RedirectEvent
+from reciperadar.models.events.search import SearchEvent
 from reciperadar.services.database import Database
 from reciperadar.workers.broker import celery
 
 
+event_table_classes = {
+    'redirects': RedirectEvent,
+    'searches': SearchEvent,
+}
+
+
 @celery.task
-def store_event(event):
+def store_event(event_table, event_data):
+    if event_table not in event_table_classes:
+        return
+    event = event_table_classes[event_table](**event_data)
+
     session = Database().get_session()
     session.add(event)
     session.commit()

--- a/tests/api/test_recipes.py
+++ b/tests/api/test_recipes.py
@@ -53,7 +53,7 @@ def test_search_recrawling(query, store, recrawl, client):
 
 
 @patch('reciperadar.api.recipes.recrawl_search.delay')
-@patch('reciperadar.api.recipes.store_event')
+@patch('reciperadar.api.recipes.store_event.delay')
 @patch.object(RecipeSearch, 'query')
 def test_bot_search(query, store, recrawl, client):
     query.return_value = {'results': [], 'total': 0}
@@ -65,4 +65,4 @@ def test_bot_search(query, store, recrawl, client):
     client.get('/api/recipes/search', headers={'user-agent': user_agent})
 
     assert store.called
-    assert store.call_args[0][0].suspected_bot
+    assert store.call_args[1]['event_data']['suspected_bot'] is True


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Instead of synchronously writing event logs during API request processing, we should queue the events to be written to the database later.

### Briefly summarize the changes
1. Write the event type and fields to a [`celery`](https://docs.celeryproject.org) task queue instead of directly to the database

**List any issues that this change relates to**
Relates to openculinary/infrastructure#8
