### PR TITLE
Autosuggest: use recently-added edge ngram field to provide typo-tolerant ingredient name suggestions

### DIFF
--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -74,7 +74,7 @@ class RecipeIngredient(Storable, Searchable):
                       'should': [
                         {
                           'match': {
-                            'ingredients.product.product_autocomplete': {
+                            'ingredients.product.product.autocomplete': {
                               'query': prefix,
                               'operator': 'AND',
                               'fuzziness': 'AUTO'

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -70,12 +70,19 @@ class RecipeIngredient(Storable, Searchable):
                 # filter to product names which match the user search
                 'products': {
                   'filter': {
-                    'match': {
-                      'ingredients.product.product_autocomplete': {
-                        'query': prefix,
-                        'operator': 'AND',
-                        'fuzziness': 'AUTO'
-                      }
+                    'bool': {
+                      'should': [
+                        {
+                          'match': {
+                            'ingredients.product.product_autocomplete': {
+                              'query': prefix,
+                              'operator': 'AND',
+                              'fuzziness': 'AUTO'
+                            }
+                          }
+                        },
+                        {'prefix': {'ingredients.product.product': prefix}}
+                      ]
                     }
                   },
                   'aggregations': {

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -70,11 +70,10 @@ class RecipeIngredient(Storable, Searchable):
                 # filter to product names which match the user search
                 'products': {
                   'filter': {
-                    'bool': {
-                      'should': [
-                        {'match': {'ingredients.product.product': prefix}},
-                        {'prefix': {'ingredients.product.product': prefix}}
-                      ]
+                    'fuzzy': {
+                      'ingredients.product.product.autocomplete': {
+                        'value': prefix
+                      }
                     }
                   },
                   'aggregations': {

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -73,6 +73,7 @@ class RecipeIngredient(Storable, Searchable):
                     'match': {
                       'ingredients.product.product_autocomplete': {
                         'query': prefix,
+                        'operator': 'AND',
                         'fuzziness': 'AUTO'
                       }
                     }

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -70,9 +70,10 @@ class RecipeIngredient(Storable, Searchable):
                 # filter to product names which match the user search
                 'products': {
                   'filter': {
-                    'fuzzy': {
+                    'match': {
                       'ingredients.product.product_autocomplete': {
-                        'value': prefix
+                        'query': prefix,
+                        'fuzziness': 'AUTO'
                       }
                     }
                   },

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -71,7 +71,7 @@ class RecipeIngredient(Storable, Searchable):
                 'products': {
                   'filter': {
                     'fuzzy': {
-                      'ingredients.product.product.autocomplete': {
+                      'ingredients.product.product_autocomplete': {
                         'value': prefix
                       }
                     }


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Building on support provided by openculinary/backend#12, this changeset uses the recently-added `ingredient.product.product.autocomplete` edge ngram multi-field to provide typo-tolerant ingredient suggestions.

Support for partial-ingredient-name matching as defined in #37 is maintained.

### Briefly summarize the changes
1. Perform fuzzy queries over the `ingredient.product.product.autocomplete` field during ingredient autosuggestion

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Fixes #20 
