### PR TITLE
Response format: render ingredient quantities as standalone objects

### DIFF
--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -46,8 +46,10 @@ class RecipeIngredient(Storable, Searchable):
         return {
             'markup': self.markup,
             'product': self.product.to_dict(include),
-            'quantity': self.quantity,
-            'units': self.units,
+            'quantity': {
+                'magnitude': self.quantity,
+                'units': self.units,
+            }
         }
 
     def to_doc(self):


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
The current client-side representation for a quantity is an object that contains a `magnitude` and a defined `units`.  This changeset adjusts the recipe search API response to return ingredient quantities as objects natively.