### PR TITLE
Search: adjust query easing behaviour

### DIFF
--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -167,6 +167,7 @@ class RecipeSearch(QueryRepository):
                 exclude=exclude,
                 equipment=equipment,
                 sort=sort,
+                exact_match=False,
                 min_include_match=0
             )
             yield query, sort_method, 'match_any'

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -308,7 +308,7 @@ class RecipeSearch(QueryRepository):
                     'sort': sort_method,
                 }
             )
-            if results['hits']['total']['value']:
+            if results['hits']['total']['value'] >= 5:
                 break
 
         recipes = []

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -109,7 +109,8 @@ class RecipeSearch(QueryRepository):
             {'range': {'time': {'gte': 5}}},
             {'range': {'product_count': {'gt': 0}}},
         ]
-        min_include_match = min_include_match or len(should)
+        if min_include_match is None:
+            min_include_match = len(should)
 
         return {
             'function_score': {


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This changeset adjusts the behaviour of query easing.

### Briefly summarize the changes
1. Require a minimum of five results (rather than one) before accepting a query as satisfactory
1. Fix a bug regarding the number of ingredients required by the 'fallback' query case
1. Disable exact-match ingredient query behaviour on the 'fallback' query case

### How have the changes been tested?
1. Sample development searches