### PR TITLE
Remove /api prefix from service endpoints

### DIFF
--- a/reciperadar/api/equipment.py
+++ b/reciperadar/api/equipment.py
@@ -4,7 +4,7 @@ from reciperadar import app
 from reciperadar.models.recipes import RecipeEquipment
 
 
-@app.route('/api/equipment')
+@app.route('/equipment')
 def equipment():
     prefix = request.args.get('pre')
     results = RecipeEquipment().autosuggest(prefix)

--- a/reciperadar/api/feedback.py
+++ b/reciperadar/api/feedback.py
@@ -7,7 +7,7 @@ from reciperadar import app
 from reciperadar.models.feedback import Feedback
 
 
-@app.route('/api/feedback', methods=['POST'])
+@app.route('/feedback', methods=['POST'])
 def feedback():
     issue, image_data_uri = request.json
     image = urlopen(image_data_uri)

--- a/reciperadar/api/ingredients.py
+++ b/reciperadar/api/ingredients.py
@@ -4,7 +4,7 @@ from reciperadar import app
 from reciperadar.models.recipes import RecipeIngredient
 
 
-@app.route('/api/ingredients')
+@app.route('/ingredients')
 def ingredients():
     prefix = request.args.get('pre')
     results = RecipeIngredient().autosuggest(prefix)

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -8,7 +8,7 @@ from reciperadar.workers.events import store_event
 from reciperadar.workers.searches import recrawl_search
 
 
-@app.route('/api/recipes/<recipe_id>/view')
+@app.route('/recipes/<recipe_id>/view')
 def recipe_view(recipe_id):
     recipe = Recipe().get_by_id(recipe_id)
     if not recipe:
@@ -21,7 +21,7 @@ def recipe_view(recipe_id):
     return jsonify(results)
 
 
-@app.route('/api/recipes/search')
+@app.route('/recipes/search')
 def recipe_search():
     include = request.args.getlist('include[]')
     exclude = request.args.getlist('exclude[]')

--- a/reciperadar/api/redirect.py
+++ b/reciperadar/api/redirect.py
@@ -5,7 +5,7 @@ from reciperadar.models.recipes import Recipe
 from reciperadar.workers.events import store_event
 
 
-@app.route('/api/redirect/recipe/<recipe_id>')
+@app.route('/redirect/recipe/<recipe_id>')
 def recipe_redirect(recipe_id):
     recipe = Recipe().get_by_id(recipe_id)
     if not recipe:

--- a/tests/api/test_recipes.py
+++ b/tests/api/test_recipes.py
@@ -6,7 +6,7 @@ from reciperadar.search.recipes import RecipeSearch
 @patch.object(RecipeSearch, 'query')
 def test_search_invalid_sort(query, client):
     response = client.get(
-        path='/api/recipes/search',
+        path='/recipes/search',
         query_string={'sort': 'invalid'}
     )
 
@@ -22,7 +22,7 @@ def test_search_empty_query(search, store, recrawl, client, raw_recipe_hit):
     total = len(hits)
     search.return_value = {'hits': {'hits': hits, 'total': {'value': total}}}
 
-    response = client.get('/api/recipes/search')
+    response = client.get('/recipes/search')
 
     assert response.status_code == 200
     assert 'refinements' in response.json
@@ -37,7 +37,7 @@ def test_search_user_agent_optional(query, store, recrawl, get, client):
     query.return_value = {'results': [], 'total': 0}
     get.return_value = None
 
-    response = client.get('/api/recipes/search', headers={'user-agent': None})
+    response = client.get('/recipes/search', headers={'user-agent': None})
 
     assert response.status_code == 200
 
@@ -48,7 +48,7 @@ def test_search_user_agent_optional(query, store, recrawl, get, client):
 def test_search_recrawling(query, store, recrawl, client):
     query.return_value = {'results': [], 'total': 0}
 
-    response = client.get('/api/recipes/search', headers={'user-agent': None})
+    response = client.get('/recipes/search', headers={'user-agent': None})
 
     assert response.status_code == 200
     assert recrawl.called is True
@@ -64,7 +64,7 @@ def test_bot_search(query, store, recrawl, client):
         'Mozilla/5.0+',
         '(compatible; UptimeRobot/2.0; http://www.uptimerobot.com/)'
     )
-    client.get('/api/recipes/search', headers={'user-agent': user_agent})
+    client.get('/recipes/search', headers={'user-agent': user_agent})
 
     assert store.called
     assert store.call_args[1]['event_data']['suspected_bot'] is True


### PR DESCRIPTION
### Briefly summarize the changes
1. Remove the `/api` prefix from service endpoints

### How have the changes been tested?
1. Unit test coverage exercises the updated paths

**List any issues that this change relates to**
Relates to openculinary/infrastructure#23