### PR TITLE
Add author, author_url fields to recipe model

### DIFF
--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -13,6 +13,8 @@ class Recipe(Storable, Searchable):
     src = db.Column(db.String)
     dst = db.Column(db.String)
     domain = db.Column(db.String)
+    author = db.Column(db.String)
+    author_url = db.Column(db.String)
     image_src = db.Column(db.String)
     time = db.Column(db.Integer)
     servings = db.Column(db.Integer)
@@ -62,6 +64,8 @@ class Recipe(Storable, Searchable):
             src=doc['src'],
             dst=doc['dst'],
             domain=doc['domain'],
+            author=doc.get('author'),
+            author_url=doc.get('author_url'),
             image_src=doc.get('image_src'),
             ingredients=[
                 RecipeIngredient.from_doc(ingredient)
@@ -97,6 +101,8 @@ class Recipe(Storable, Searchable):
             'rating': self.rating,
             'dst': self.dst,
             'domain': self.domain,
+            'author': self.author,
+            'author_url': self.author_url,
             'image_url': self.image_path,
             'nutrition': self.nutrition.to_dict() if self.nutrition else None,
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -54,6 +54,7 @@ def raw_recipe_hit():
                     "is_gluten_free": False,
                 }
             ],
+            "author": "example",
             "image_src": "http://www.example.com/path/image.png?v=123",
             "time": 30,
             "src": "http://www.example.com/recipes/test",

--- a/tests/models/recipes/test_recipe.py
+++ b/tests/models/recipes/test_recipe.py
@@ -3,6 +3,7 @@ from reciperadar.models.recipes import Recipe
 
 def test_recipe_from_doc(raw_recipe_hit):
     recipe = Recipe().from_doc(raw_recipe_hit['_source'])
+    assert recipe.author == 'example'
 
     assert recipe.directions[0].appliances[0].appliance == 'oven'
     assert recipe.directions[0].utensils[0].utensil == 'skewer'


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
To support author attribution, the `author` and `author_url` fields from documents should be rendered by the API service for consumption and rendering by the client.

### Briefly summarize the changes
1. Retrieve and render the `author` and `author_url` fields in recipe API responses

### How have the changes been tested?
1. Unit test coverage is updated

**List any issues that this change relates to**
Relates to openculinary/backend#28.