### PR TITLE
Render recipe dietary properties

### DIFF
--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -30,6 +30,10 @@ class Recipe(Storable, Searchable):
         backref='recipe',
         passive_deletes='all'
     )
+    is_dairy_free = db.Column(db.Boolean)
+    is_gluten_free = db.Column(db.Boolean)
+    is_vegan = db.Column(db.Boolean)
+    is_vegetarian = db.Column(db.Boolean)
 
     indexed_at = db.Column(db.DateTime)
 
@@ -77,6 +81,10 @@ class Recipe(Storable, Searchable):
                 for direction in doc.get('directions') or []
                 if direction['description'].strip()
             ],
+            is_dairy_free=doc.get('is_dairy_free'),
+            is_gluten_free=doc.get('is_gluten_free'),
+            is_vegan=doc.get('is_vegan'),
+            is_vegetarian=doc.get('is_vegetarian'),
             servings=doc['servings'],
             time=doc['time'],
             rating=doc['rating'],

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -113,6 +113,10 @@ class Recipe(Storable, Searchable):
             'author_url': self.author_url,
             'image_url': self.image_path,
             'nutrition': self.nutrition.to_dict() if self.nutrition else None,
+            'is_dairy_free': self.is_dairy_free,
+            'is_gluten_free': self.is_gluten_free,
+            'is_vegan': self.is_vegan,
+            'is_vegetarian': self.is_vegetarian,
         }
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,8 @@ def raw_recipe_hit():
                 "fat": 0.01,
                 "fibre": 0.65,
                 "protein": 0.05
-            }
+            },
+            "is_vegetarian": True
         },
         "inner_hits": {"ingredients": {"hits": {"hits": []}}}
     }

--- a/tests/models/recipes/test_recipe.py
+++ b/tests/models/recipes/test_recipe.py
@@ -19,3 +19,4 @@ def test_recipe_from_doc(raw_recipe_hit):
     assert recipe.nutrition.fibre == 0.65
 
     assert 'nutrition' not in recipe.ingredients[0].to_dict()
+    assert 'is_vegetarian' in recipe.to_dict()

--- a/tests/models/recipes/test_recipe.py
+++ b/tests/models/recipes/test_recipe.py
@@ -4,6 +4,7 @@ from reciperadar.models.recipes import Recipe
 def test_recipe_from_doc(raw_recipe_hit):
     recipe = Recipe().from_doc(raw_recipe_hit['_source'])
     assert recipe.author == 'example'
+    assert recipe.is_vegetarian
 
     assert recipe.directions[0].appliances[0].appliance == 'oven'
     assert recipe.directions[0].utensils[0].utensil == 'skewer'


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Per-recipe dietary properties (`is_vegetarian`, `is_dairy_free`, ...) are written into the search index by the [`backend`](https://github.com/openculinary/backend) service during recipe indexing.

This changeset allows the API to read those properties and render them in responses to the client.

### Briefly summarize the changes
1. Read dietary properties from the recipe document
1. Render dietary properties in API responses

### How have the changes been tested?
1. Unit test coverage is updated