### PR TITLE
Provide filter-by-domain support during recipe search

### DIFF
--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -29,9 +29,15 @@ def recipe_search():
     offset = min(request.args.get('offset', type=int, default=0), (25*10)-10)
     limit = min(request.args.get('limit', type=int, default=10), 10)
     sort = request.args.get('sort', type=str)
+    domains = request.args.getlist('domains[]')
 
     if sort and sort not in RecipeSearch.sort_methods():
         return abort(400)
+
+    domains = {
+        'exclude': list(filter(lambda x: x.startswith('-'), domains)),
+        'include': list(filter(lambda x: not x.startswith('-'), domains)),
+    }
 
     results = RecipeSearch().query(
         include=include,
@@ -39,7 +45,8 @@ def recipe_search():
         equipment=equipment,
         offset=offset,
         limit=limit,
-        sort=sort
+        sort=sort,
+        domains=domains
     )
 
     user_agent = request.headers.get('user-agent')

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -21,6 +21,16 @@ def recipe_view(recipe_id):
     return jsonify(results)
 
 
+def partition_query_terms(terms):
+    partitions = {'include': [], 'exclude': []}
+    for term in terms:
+        term_length = len(term)
+        term = term.lstrip('-')
+        partition = 'include' if len(term) == term_length else 'exclude'
+        partitions[partition].append(term)
+    return partitions
+
+
 @app.route('/recipes/search')
 def recipe_search():
     include = request.args.getlist('include[]')
@@ -34,10 +44,7 @@ def recipe_search():
     if sort and sort not in RecipeSearch.sort_methods():
         return abort(400)
 
-    domains = {
-        'exclude': list(filter(lambda x: x.startswith('-'), domains)),
-        'include': list(filter(lambda x: not x.startswith('-'), domains)),
-    }
+    domains = partition_query_terms(domains)
 
     results = RecipeSearch().query(
         include=include,

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -94,13 +94,17 @@ class RecipeSearch(QueryRepository):
         return self.sort_methods()[sort]
 
     def _generate_post_filter(self, domains):
-        include_domains = [{'match': domain} for domain in domains['include']]
-        exclude_domains = [{'match': domain} for domain in domains['exclude']]
         conditions = {}
-        if include_domains:
-            conditions['must'] = include_domains
-        if exclude_domains:
-            conditions['must_not'] = exclude_domains
+        if domains['include']:
+            conditions['must'] = [
+                {'match': {'domain': domain}}
+                for domain in domains['include']
+            ]
+        if domains['exclude']:
+            conditions['must_not'] = [
+                {'match': {'domain': domain}}
+                for domain in domains['exclude']
+            ]
         return {'bool': conditions}
 
     def _render_query(self, include, exclude, equipment, sort,

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -96,14 +96,12 @@ class RecipeSearch(QueryRepository):
     def _generate_post_filter(self, domains):
         include_domains = [{'match': domain} for domain in domains['include']]
         exclude_domains = [{'match': domain} for domain in domains['exclude']]
-        if not include_domains and not exclude_domains:
-            return {}
-        return {
-            'bool': {
-                'must': include_domains,
-                'must_not': exclude_domains,
-            }
-        }
+        conditions = {}
+        if include_domains:
+            conditions['must'] = include_domains
+        if exclude_domains:
+            conditions['must_not'] = exclude_domains
+        return {'bool': conditions}
 
     def _render_query(self, include, exclude, equipment, sort,
                       exact_match=True, min_include_match=None):

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -324,9 +324,18 @@ class RecipeSearch(QueryRepository):
             recipe = Recipe.from_doc(result['_source'])
             recipes.append(recipe.to_dict(include))
 
+        facets = {}
+        for field, aggregation in results['aggregations'].items():
+            buckets = aggregation['buckets']
+            facets[field] = {
+                bucket['key']: bucket['doc_count']
+                for bucket in buckets
+            }
+
         return {
             'authority': 'api',
             'total': min(results['hits']['total']['value'], 25 * limit),
             'results': recipes,
+            'facets': facets,
             'refinements': [refinement] if recipes and refinement else []
         }

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -328,7 +328,7 @@ class RecipeSearch(QueryRepository):
         for field, aggregation in results['aggregations'].items():
             buckets = aggregation['buckets']
             facets[field] = {
-                bucket['key']: bucket['doc_count']
+                bucket['key']: min(bucket['doc_count'], 100)
                 for bucket in buckets
             }
 

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -112,6 +112,12 @@ class RecipeSearch(QueryRepository):
         if min_include_match is None:
             min_include_match = len(should)
 
+        aggregations = {
+            'domains': {
+                'terms': {'field': 'domain'},
+            }
+        }
+
         return {
             'function_score': {
                 'boost_mode': 'replace',
@@ -123,6 +129,7 @@ class RecipeSearch(QueryRepository):
                         'minimum_should_match': min_include_match,
                     }
                 },
+                'aggs': aggregations,
                 'script_score': {'script': {'source': sort_params['script']}}
             }
         }, [{'_score': sort_params['order']}]

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -112,12 +112,6 @@ class RecipeSearch(QueryRepository):
         if min_include_match is None:
             min_include_match = len(should)
 
-        aggregations = {
-            'domains': {
-                'terms': {'field': 'domain'},
-            }
-        }
-
         return {
             'function_score': {
                 'boost_mode': 'replace',
@@ -129,7 +123,6 @@ class RecipeSearch(QueryRepository):
                         'minimum_should_match': min_include_match,
                     }
                 },
-                'aggs': aggregations,
                 'script_score': {'script': {'source': sort_params['script']}}
             }
         }, [{'_score': sort_params['order']}]
@@ -300,6 +293,12 @@ class RecipeSearch(QueryRepository):
         limit = max(1, limit)
         limit = min(25, limit)
 
+        aggregations = {
+            'domains': {
+                'terms': {'field': 'domain'},
+            }
+        }
+
         queries = self._refined_queries(
             include=include,
             exclude=exclude,
@@ -314,6 +313,7 @@ class RecipeSearch(QueryRepository):
                     'size': limit,
                     'query': query,
                     'sort': sort_method,
+                    'aggs': aggregations,
                 }
             )
             if results['hits']['total']['value'] >= 5:

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -309,7 +309,7 @@ class RecipeSearch(QueryRepository):
 
         aggregations = {
             'domains': {
-                'terms': {'field': 'domain'},
+                'terms': {'field': 'domain', 'size': 100},
             }
         }
 

--- a/tests/api/test_recipes.py
+++ b/tests/api/test_recipes.py
@@ -20,7 +20,10 @@ def test_search_invalid_sort(query, client):
 def test_search_empty_query(search, store, recrawl, client, raw_recipe_hit):
     hits = [raw_recipe_hit]
     total = len(hits)
-    search.return_value = {'hits': {'hits': hits, 'total': {'value': total}}}
+    search.return_value = {
+        'hits': {'hits': hits, 'total': {'value': total}},
+        'aggregations': {},
+    }
 
     response = client.get('/recipes/search')
 

--- a/tests/api/test_recipes.py
+++ b/tests/api/test_recipes.py
@@ -1,6 +1,16 @@
 from unittest.mock import patch
 
+from reciperadar.api.recipes import partition_query_terms
 from reciperadar.search.recipes import RecipeSearch
+
+
+def test_query_term_partitioning():
+    terms = ['tomato', '-garlic', 'olives']
+    partitions = partition_query_terms(terms)
+    assert partitions == {
+        'include': ['tomato', 'olives'],
+        'exclude': ['garlic'],
+    }
 
 
 @patch.object(RecipeSearch, 'query')


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Some users may prefer to see results from particular recipe websites, and/or to exclude specific recipe websites from their search results.

In order to support this type of functionality, we introduce [faceted search](https://en.wikipedia.org/wiki/Faceted_search) over recipe website domains.

When a search query occurs, the API response will include aggregate per-domain recipe counts.  The client can then construct subsequent search queries that include/exclude any named domains.

### Briefly summarize the changes
1. Include per-domain recipe counts in the API response
1. Add support for domain inclusion and exclusion filtering in API requests

### How have the changes been tested?
1. Local development testing
1. Some unit test coverage is provided