### PR TITLE
Provide search-by-dietary-properties functionality

### DIFF
--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -44,8 +44,8 @@ def recipe_search():
     dietary_properties = {
         dietary_property: True
         for dietary_property in [
-            'dairy_free',
-            'gluten_free',
+            'dairy-free',
+            'gluten-free',
             'vegan',
             'vegetarian',
         ]

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -41,6 +41,17 @@ def recipe_search():
     sort = request.args.get('sort', type=str)
     domains = request.args.getlist('domains[]')
 
+    dietary_properties = {
+        dietary_property: True
+        for dietary_property in [
+            'dairy_free',
+            'gluten_free',
+            'vegan',
+            'vegetarian',
+        ]
+        if dietary_property in request.args
+    }
+
     if sort and sort not in RecipeSearch.sort_methods():
         return abort(400)
 
@@ -53,7 +64,8 @@ def recipe_search():
         offset=offset,
         limit=limit,
         sort=sort,
-        domains=domains
+        domains=domains,
+        dietary_properties=dietary_properties,
     )
 
     user_agent = request.headers.get('user-agent')

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -109,7 +109,7 @@ class RecipeSearch(QueryRepository):
             ]
         if dietary_properties:
             conditions['must'] += [
-                {'match': {f'is_{dietary_property}': True}}
+                {'match': {f'is_{dietary_property.replace("-", "_")}': True}}
                 for dietary_property in dietary_properties
             ]
         return {'bool': conditions}

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -1,3 +1,5 @@
+from collections import defaultdict
+
 from reciperadar.models.recipes import Recipe
 from reciperadar.search.base import QueryRepository
 
@@ -94,14 +96,14 @@ class RecipeSearch(QueryRepository):
         return self.sort_methods()[sort]
 
     def _generate_post_filter(self, domains):
-        conditions = {}
+        conditions = defaultdict(list)
         if domains['include']:
-            conditions['must'] = [
+            conditions['must'] += [
                 {'match': {'domain': domain}}
                 for domain in domains['include']
             ]
         if domains['exclude']:
-            conditions['must_not'] = [
+            conditions['must_not'] += [
                 {'match': {'domain': domain}}
                 for domain in domains['exclude']
             ]


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Since #84 dietary properties have been rendered in API responses on each recipe in the search results.  This provides a way for people to visually inspect the properties of each recipe result.

In many cases it may be preferable to search for recipes with specific dietary properties in mind.  This changeset adds support for recipe search using each of the currently-available dietary properties (`dairy-free`, `gluten-free`, `vegan`, `vegetarian`).

### Briefly summarize the changes
1. Accept search request parameters for each of the dietary properties
1. Filter search results appropriately to match the dietary properties requested

### How have the changes been tested?
1. Local development testing