### PR TITLE
Query refinement: use pre-filtered document count to determine per-query success

### DIFF
--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -341,7 +341,15 @@ class RecipeSearch(QueryRepository):
                     'post_filter': post_filter,
                 }
             )
-            if results['hits']['total']['value'] >= 5:
+
+            # Ignoring the displayed hits, sum the document counts across
+            # one of the facets (summing across all facets would double-count)
+            doc_count = 0
+            for aggregation in results['aggregations'].values():
+                for bucket in aggregation['buckets']:
+                    doc_count += bucket['doc_count']
+                break
+            if doc_count >= 5:
                 break
 
         recipes = []


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
As detailed in #87, query refinement has had unexpected interactions with user selection/deselection of search result facet items.

This is primarily due to the use of the `hits.total.value` field in the Elasticsearch response, which provides a post-filtered result count.

Instead we can access a 'stable' pre-filtered document count by aggregating the total documents found over an arbitrarily-selected facet dimension.

The reason we pick just one aggregation over which to perform a sum is that a search may involve multiple aggregations, and summing across all of these could result in totals that have summed the document population multiple times (this would have been quickly apparent by noticing that the totals were a multiple of the unfiltered result count).

### Briefly summarize the changes
1. Use the aggregated document count (pre-filtered) in preference to the search results (post-filtered) to determine the number of results for each query refinement and whether it should be considered successful

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Fixes #87.