### PR TITLE
Rename the IngredientProduct model to Product

### DIFF
--- a/reciperadar/models/recipes/__init__.py
+++ b/reciperadar/models/recipes/__init__.py
@@ -2,4 +2,3 @@ from .recipe import Recipe
 from .direction import RecipeDirection
 from .equipment import RecipeEquipment
 from .ingredient import RecipeIngredient
-from .product import IngredientProduct

--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -4,14 +4,13 @@ from reciperadar import db
 from reciperadar.models.base import Storable
 
 
-class IngredientProduct(Storable):
+class Product(Storable):
     __tablename__ = 'ingredient_products'
 
     fk = db.ForeignKey('recipe_ingredients.id', ondelete='cascade')
     ingredient_id = db.Column(db.String, fk, index=True)
 
     id = db.Column(db.String, primary_key=True)
-    product_id = db.Column(db.String)
     product = db.Column(db.String)
     product_parser = db.Column(db.String)
     is_plural = db.Column(db.Boolean)
@@ -25,14 +24,12 @@ class IngredientProduct(Storable):
 
     @staticmethod
     def from_doc(doc):
-        product_id = doc.get('id') or IngredientProduct.generate_id()
         plural = doc.get('plural')
         singular = doc.get('singular')
         is_plural = doc.get('is_plural')
         product = plural if is_plural else singular
-        return IngredientProduct(
-            id=product_id,
-            product_id=doc.get('product_id'),
+        return Product(
+            id=doc.get('id'),
             product=product,
             product_parser=doc.get('product_parser'),
             is_plural=is_plural,
@@ -44,15 +41,15 @@ class IngredientProduct(Storable):
 
     def state(self, include):
         states = {
-            True: IngredientProduct.STATE_AVAILABLE,
-            False: IngredientProduct.STATE_REQUIRED,
+            True: Product.STATE_AVAILABLE,
+            False: Product.STATE_REQUIRED,
         }
         available = bool(set(self.contents or []) & set(include or []))
         return states[available]
 
     def to_dict(self, include):
         return {
-            'product_id': self.product_id,
+            'product_id': self.id,
             'product': self.product,
             'category': self.category,
             'singular': self.singular,

--- a/tests/models/recipes/test_recipe.py
+++ b/tests/models/recipes/test_recipe.py
@@ -9,7 +9,7 @@ def test_recipe_from_doc(raw_recipe_hit):
     assert recipe.directions[0].appliances[0].appliance == 'oven'
     assert recipe.directions[0].utensils[0].utensil == 'skewer'
 
-    assert recipe.ingredients[0].product.product == 'one'
+    assert recipe.ingredients[0].product.singular == 'one'
     expected_contents = ['one', 'content-of-one', 'ancestor-of-one']
     actual_contents = recipe.ingredients[0].product.contents
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This changeset mirrors the database model changes applied in openculinary/backend#35 and openculinary/backend#37.

### Briefly summarize the changes
1. Rename the `IngredientProduct` model to `Product`

### How have the changes been tested?
1. Unit test coverage continues to pass

**List any issues that this change relates to**
Relates to openculinary/backend#34.