### PR TITLE
Query refinement: use match-all aggregation to determine per-query success

### DIFF
--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -359,13 +359,11 @@ class RecipeSearch(QueryRepository):
             recipe = Recipe.from_doc(result['_source'])
             recipes.append(recipe.to_dict(include))
 
-        facets = {}
-        for field, content in results['aggregations']['prefilter'].items():
-            if not isinstance(content, dict) or 'buckets' not in content:
-                continue
+        for field in facets:
+            buckets = results['aggregations']['prefilter'][field]['buckets']
             facets[field] = {
                 bucket['key']: min(bucket['doc_count'], 100)
-                for bucket in content['buckets']
+                for bucket in buckets
             }
 
         return {

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -95,6 +95,14 @@ class RecipeSearch(QueryRepository):
             return {'script': 'doc.rating.value', 'order': 'desc'}
         return self.sort_methods()[sort]
 
+    def _generate_aggregations(self, facets):
+        return {
+            'prefilter': {
+                'filter': {'match_all': {}},
+                'aggs': facets,
+            }
+        }
+
     def _generate_post_filter(self, domains, dietary_properties):
         conditions = defaultdict(list)
         if domains['include']:
@@ -315,12 +323,13 @@ class RecipeSearch(QueryRepository):
         limit = max(1, limit)
         limit = min(25, limit)
 
-        aggregations = {
+        facets = {
             'domains': {
                 'terms': {'field': 'domain', 'size': 100},
             }
         }
 
+        aggregations = self._generate_aggregations(facets)
         post_filter = self._generate_post_filter(domains, dietary_properties)
 
         queries = self._refined_queries(
@@ -342,14 +351,7 @@ class RecipeSearch(QueryRepository):
                 }
             )
 
-            # Ignoring the displayed hits, sum the document counts across
-            # one of the facets (summing across all facets would double-count)
-            doc_count = 0
-            for aggregation in results['aggregations'].values():
-                for bucket in aggregation['buckets']:
-                    doc_count += bucket['doc_count']
-                break
-            if doc_count >= 5:
+            if results['aggregations']['prefilter']['doc_count'] >= 5:
                 break
 
         recipes = []
@@ -358,11 +360,12 @@ class RecipeSearch(QueryRepository):
             recipes.append(recipe.to_dict(include))
 
         facets = {}
-        for field, aggregation in results['aggregations'].items():
-            buckets = aggregation['buckets']
+        for field, content in results['aggregations']['prefilter'].items():
+            if not isinstance(content, dict) or 'buckets' not in content:
+                continue
             facets[field] = {
                 bucket['key']: min(bucket['doc_count'], 100)
-                for bucket in buckets
+                for bucket in content['buckets']
             }
 
         return {

--- a/tests/api/test_recipes.py
+++ b/tests/api/test_recipes.py
@@ -45,6 +45,7 @@ def test_search_empty_query(search, store, recrawl, client, raw_recipe_hit):
     assert response.status_code == 200
     assert 'refinements' in response.json
     assert 'empty_query' in response.json['refinements']
+    assert 'domains' in response.json['facets']
 
 
 @patch('werkzeug.datastructures.Headers.get')

--- a/tests/api/test_recipes.py
+++ b/tests/api/test_recipes.py
@@ -32,7 +32,12 @@ def test_search_empty_query(search, store, recrawl, client, raw_recipe_hit):
     total = len(hits)
     search.return_value = {
         'hits': {'hits': hits, 'total': {'value': total}},
-        'aggregations': {},
+        'aggregations': {
+            'prefilter': {
+                'doc_count': 0,
+                'domains': {'buckets': []},
+            }
+        },
     }
 
     response = client.get('/recipes/search')


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Previously in #88 a change was introduced that retrieves the 'total matching document count' (used to determine whether query refinement has succeeded in returning a sufficient number of results) by summing over the document counts from an aggregation returned by Elasticsearch.

This works well but does have some slightly non-ideal properties:

- It requires at least one search-specific aggregation to be performed
- It requires a summation operation in the client
- The logic involved to sum only over one facet dimension is slightly non-intuitive; it's relatively safe when commented, but still unusual

An alternative approach suggested by @polyfractal in https://github.com/elastic/elasticsearch/issues/64836#issuecomment-729908369 is to use a top-level `filter` aggregation in combination with the `match_all` predicate.

Zero or more search-related aggregations can be nested within the top-level aggregation, and in all cases the search response will contain a top-level `doc_count` at a fixed path.

Performance remains a question.  Given that the nested aggregation case is simple and that the `match_all` predicate may be optimizable by the Elasticsearch engine, the optimistic case is that the performance impact would be negligible.

### How have the changes been tested?
1. Unit test coverage is updated

**List any issues that this change relates to**
Resolves #87.