### PR TITLE
Update representation of ingredients in the search index

### DIFF
--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -48,8 +48,8 @@ class RecipeIngredient(Storable, Searchable):
             description=doc['description'].strip(),
             markup=doc.get('markup'),
             product=Product.from_doc(doc['product']),
-            product_id=doc['product'].get('product_id'),
-            product_is_plural=doc['product'].get('is_plural'),
+            product_id=doc['product'].get('id'),
+            product_is_plural=doc.get('product_is_plural'),
             product_parser=doc['product'].get('product_parser'),
             nutrition=IngredientNutrition.from_doc(nutrition)
             if nutrition else None,
@@ -89,14 +89,14 @@ class RecipeIngredient(Storable, Searchable):
                       'should': [
                         {
                           'match': {
-                            'ingredients.product.product.autocomplete': {
+                            'ingredients.product_name.autocomplete': {
                               'query': prefix,
                               'operator': 'AND',
                               'fuzziness': 'AUTO'
                             }
                           }
                         },
-                        {'prefix': {'ingredients.product.product': prefix}}
+                        {'prefix': {'ingredients.product_name': prefix}}
                       ]
                     }
                   },
@@ -104,7 +104,7 @@ class RecipeIngredient(Storable, Searchable):
                     # retrieve the top products in singular pluralization
                     'product_id': {
                       'terms': {
-                        'field': 'ingredients.product.product_id',
+                        'field': 'ingredients.product.id',
                         'min_doc_count': 5,
                         'size': 10
                       },
@@ -112,7 +112,7 @@ class RecipeIngredient(Storable, Searchable):
                         # count products that were plural in the source recipe
                         'plurality': {
                           'filter': {
-                            'match': {'ingredients.product.is_plural': True}
+                            'match': {'ingredients.product_is_plural': True}
                           }
                         },
                         # retrieve a category for each ingredient

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -159,12 +159,13 @@ class RecipeIngredient(Storable, Searchable):
             singular = (result['singular']['buckets'] or [{}])[0].get('key')
             plural = (result['plural']['buckets'] or [{}])[0].get('key')
 
-            suggestions.append((Product(
+            suggestions.append(Product(
                 id=product_id,
+                product=plural if plural_wins else singular,
                 category=category,
                 singular=singular,
                 plural=plural,
-            ), plural_wins))
+            ))
 
         suggestions.sort(key=lambda s: (
             s.product != prefix,  # exact matches first
@@ -172,9 +173,9 @@ class RecipeIngredient(Storable, Searchable):
             len(s.product)),  # sort remaining matches by length
         )
         return [{
-            'product_id': product.id,
-            'product': product.plural if plural_wins else product.singular,
-            'category': product.category,
-            'singular': product.singular,
-            'plural': product.plural,
-        } for product, plural_wins in suggestions]
+            'product_id': suggestion.id,
+            'product': suggestion.product,
+            'category': suggestion.category,
+            'singular': suggestion.singular,
+            'plural': suggestion.plural,
+        } for suggestion in suggestions]

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -159,13 +159,12 @@ class RecipeIngredient(Storable, Searchable):
             singular = (result['singular']['buckets'] or [{}])[0].get('key')
             plural = (result['plural']['buckets'] or [{}])[0].get('key')
 
-            suggestions.append(Product(
+            suggestions.append((Product(
                 id=product_id,
-                product=plural if plural_wins else singular,
                 category=category,
                 singular=singular,
                 plural=plural,
-            ))
+            ), plural_wins))
 
         suggestions.sort(key=lambda s: (
             s.product != prefix,  # exact matches first
@@ -173,9 +172,9 @@ class RecipeIngredient(Storable, Searchable):
             len(s.product)),  # sort remaining matches by length
         )
         return [{
-            'product_id': suggestion.id,
-            'product': suggestion.product,
-            'category': suggestion.category,
-            'singular': suggestion.singular,
-            'plural': suggestion.plural,
-        } for suggestion in suggestions]
+            'product_id': product.id,
+            'product': product.plural if plural_wins else product.singular,
+            'category': product.category,
+            'singular': product.singular,
+            'plural': product.plural,
+        } for product, plural_wins in suggestions]

--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -159,22 +159,23 @@ class RecipeIngredient(Storable, Searchable):
             singular = (result['singular']['buckets'] or [{}])[0].get('key')
             plural = (result['plural']['buckets'] or [{}])[0].get('key')
 
-            suggestions.append(Product(
+            product = Product(
                 id=product_id,
-                product=plural if plural_wins else singular,
                 category=category,
                 singular=singular,
                 plural=plural,
-            ))
+            )
+            product.name = plural if plural_wins else singular
+            suggestions.append(product)
 
         suggestions.sort(key=lambda s: (
-            s.product != prefix,  # exact matches first
-            not s.product.startswith(prefix),  # prefix matches next
-            len(s.product)),  # sort remaining matches by length
+            s.name != prefix,  # exact matches first
+            not s.name.startswith(prefix),  # prefix matches next
+            len(s.name)),  # sort remaining matches by length
         )
         return [{
             'product_id': suggestion.id,
-            'product': suggestion.product,
+            'product': suggestion.name,
             'category': suggestion.category,
             'singular': suggestion.singular,
             'plural': suggestion.plural,

--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -7,13 +7,11 @@ from reciperadar.models.base import Storable
 class Product(Storable):
     __tablename__ = 'ingredient_products'
 
-    fk = db.ForeignKey('recipe_ingredients.id', ondelete='cascade')
-    ingredient_id = db.Column(db.String, fk, index=True)
+    ingredient_fk = db.ForeignKey('recipe_ingredients.id', ondelete='cascade')
+    ingredient_id = db.Column(db.String, ingredient_fk, index=True)
 
     id = db.Column(db.String, primary_key=True)
-    product = db.Column(db.String)
     product_parser = db.Column(db.String)
-    is_plural = db.Column(db.Boolean)
     singular = db.Column(db.String)
     plural = db.Column(db.String)
     category = db.Column(db.String)
@@ -24,17 +22,11 @@ class Product(Storable):
 
     @staticmethod
     def from_doc(doc):
-        plural = doc.get('plural')
-        singular = doc.get('singular')
-        is_plural = doc.get('is_plural')
-        product = plural if is_plural else singular
         return Product(
             id=doc.get('id'),
-            product=product,
             product_parser=doc.get('product_parser'),
-            is_plural=is_plural,
-            singular=singular,
-            plural=plural,
+            singular=doc.get('singular'),
+            plural=doc.get('plural'),
             category=doc.get('category'),
             contents=doc.get('contents'),
         )
@@ -50,7 +42,6 @@ class Product(Storable):
     def to_dict(self, include):
         return {
             'product_id': self.id,
-            'product': self.product,
             'category': self.category,
             'singular': self.singular,
             'plural': self.plural,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,13 +36,14 @@ def raw_recipe_hit():
                     "product": {
                         "singular": "one",
                         "plural": "ones",
-                        "is_plural": False,
                         "contents": [
                             "one",
                             "content-of-one",
                             "ancestor-of-one",
                         ],
                     },
+                    "product_is_plural": False,
+                    "product_name": "one",
                     "nutrition": {
                         "carbohydrates": 0,
                         "energy": 0,
@@ -55,8 +56,10 @@ def raw_recipe_hit():
                     "index": 1,
                     "description": "two units of test ingredient two",
                     "product": {
-                        "product": "two"
-                    }
+                        "singular": "two"
+                    },
+                    "product_is_plural": False,
+                    "product_name": "two"
                 }
             ],
             "author": "example",


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This changeset mirrors openculinary/backend#39, applying updates to the representation of recipe ingredients queried and retrieved from the Elasticsearch index.

### Briefly summarize the changes
1. `product.product_id` field is renamed to `product.id` (rationale: the word 'product' is implied)
1. `ingredient.product.is_plural` field is renamed to `ingredient.product_is_plural` (rationale: an abstract product only takes a singular/plural form concretely inside the written context of an ingredient)
1. `ingredient.product.product` field is renamed to `ingredient.product_name` (rationale: this is more comprehensible)

### How have the changes been tested?
1. Local development testing of the autosuggest and search functions following reindexing of content
1. Unit test coverage is updated, although it does not currently effectively cover search-engine-related changes

**List any issues that this change relates to**
Relates to openculinary/backend#34.