### PR TITLE
Update product entity field names

### DIFF
--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -38,6 +38,13 @@ class RecipeIngredient(Storable, Searchable):
     product_parser = db.Column(db.String)
     verb = db.Column(db.String)
 
+    @property
+    def product_name(self):
+        if self.product_is_plural:
+            return self.product.plural
+        else:
+            return self.product.singular
+
     @staticmethod
     def from_doc(doc):
         ingredient_id = doc.get('id') or RecipeIngredient.generate_id()
@@ -63,7 +70,10 @@ class RecipeIngredient(Storable, Searchable):
     def to_dict(self, include=None):
         return {
             'markup': self.markup,
-            'product': self.product.to_dict(include),
+            'product': {
+                **self.product.to_dict(include),
+                **{'name': self.product_name},
+            },
             'quantity': {
                 'magnitude': self.magnitude,
                 'units': self.units,
@@ -174,8 +184,8 @@ class RecipeIngredient(Storable, Searchable):
             len(s.name)),  # sort remaining matches by length
         )
         return [{
-            'product_id': suggestion.id,
-            'product': suggestion.name,
+            'id': suggestion.id,
+            'name': suggestion.name,
             'category': suggestion.category,
             'singular': suggestion.singular,
             'plural': suggestion.plural,

--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -41,7 +41,7 @@ class Product(Storable):
 
     def to_dict(self, include):
         return {
-            'product_id': self.id,
+            'id': self.id,
             'category': self.category,
             'singular': self.singular,
             'plural': self.plural,


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This changeset cleans up some product-related field names used during communication with the [`frontend`](https://github.com/openculinary/frontend) application.

### Briefly summarize the changes
- `product.product_id` is renamed to `product.id` (rationale: the `product_` prefix is implied)
- `product.product` is renamed to `product.name` (rationale: the duplication of the term `product` is confusing)

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Supports openculinary/frontend#178.