### PR TITLE
Add recipe exploration endpoint

### DIFF
--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -91,3 +91,28 @@ def recipe_search():
     )
 
     return jsonify(results)
+
+
+@app.route('/recipes/explore')
+def recipe_explore():
+    include = request.args.getlist('include[]')
+    exclude = request.args.getlist('exclude[]')
+
+    dietary_properties = {
+        dietary_property: True
+        for dietary_property in [
+            'dairy-free',
+            'gluten-free',
+            'vegan',
+            'vegetarian',
+        ]
+        if dietary_property in request.args
+    }
+
+    results = RecipeSearch().explore(
+        include=include,
+        exclude=exclude,
+        dietary_properties=dietary_properties,
+    )
+
+    return jsonify(results)

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -100,17 +100,7 @@ def recipe_search():
 def recipe_explore():
     include = request.args.getlist('include[]')
     exclude = request.args.getlist('exclude[]')
-
-    dietary_properties = {
-        dietary_property: True
-        for dietary_property in [
-            'dairy-free',
-            'gluten-free',
-            'vegan',
-            'vegetarian',
-        ]
-        if dietary_property in request.args
-    }
+    dietary_properties = extract_dietary_properties(request.args)
 
     results = RecipeSearch().explore(
         include=include,

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -463,5 +463,6 @@ class RecipeSearch(QueryRepository):
         return {
             'authority': 'api',
             'choices': choices,
+            'total': min(results['hits']['total']['value'], 25 * limit),
             'results': recipes,
         }

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -134,7 +134,7 @@ class RecipeSearch(QueryRepository):
                 'terms': {
                     'field': 'ingredients.product.singular',
                     'order': {'_count': 'desc'},
-                    'size': 10
+                    'size': 50
                 }
             }
         }

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -450,7 +450,7 @@ class RecipeSearch(QueryRepository):
 
         choices = prefiltered['ingredients']['choices']['products']['buckets']
         choices.sort(key=lambda choice: abs(choice['doc_count'] - (total / 2)))
-        choices = [choices['key'] for choice in choices]
+        choices = [choice['key'] for choice in choices]
 
         recipes = []
         for result in results['hits']['hits']:

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -134,7 +134,7 @@ class RecipeSearch(QueryRepository):
                 'terms': {
                     'field': 'ingredients.product.singular',
                     'order': {'_count': 'desc'},
-                    'size': 5
+                    'size': 10
                 }
             }
         }

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -447,8 +447,10 @@ class RecipeSearch(QueryRepository):
 
         prefiltered = results['aggregations']['prefilter']
         total = prefiltered['doc_count']
+
         choices = prefiltered['ingredients']['choices']['products']['buckets']
         choices.sort(key=lambda choice: abs(choice['doc_count'] - (total / 2)))
+        choices = [choices['key'] for choice in choices]
 
         recipes = []
         for result in results['hits']['hits']:

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -434,7 +434,7 @@ class RecipeSearch(QueryRepository):
 
             products = prefilter['products']['choices']['singular']['buckets']
             products.sort(key=lambda x: abs(x['doc_count'] - (total / 2)))
-            prefilter['products'] = {'buckets': products}
+            prefilter['products'] = {'buckets': products[:10]}
 
         facets = {}
         for field, content in results['aggregations']['prefilter'].items():

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -363,11 +363,13 @@ class RecipeSearch(QueryRepository):
             recipe = Recipe.from_doc(result['_source'])
             recipes.append(recipe.to_dict(include))
 
-        for field in facets:
-            buckets = results['aggregations']['prefilter'][field]['buckets']
+        facets = {}
+        for field, content in results['aggregations']['prefilter'].items():
+            if not isinstance(content, dict) or 'buckets' not in content:
+                continue
             facets[field] = {
                 bucket['key']: min(bucket['doc_count'], 100)
-                for bucket in buckets
+                for bucket in content['buckets']
             }
 
         return {

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -111,8 +111,11 @@ class RecipeSearch(QueryRepository):
         return {
             'bool': {
                 'must': [
-                    {'term': {f'ingredients.product.is_{dietary_property.replace("-", "_")}': True}}
-                    for dietary_property in dietary_properties
+                    {'term': {f'ingredients.product.{dietary_property}': True}}
+                    for dietary_property in [
+                        f'is_{dietary_property.replace("-", "_")}'
+                        for dietary_property in dietary_properties
+                    ]
                 ],
                 'must_not': [
                     # Do not present staple ingredients as choices

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -417,7 +417,7 @@ class RecipeSearch(QueryRepository):
             ingredients = prefilter.pop('ingredients')
             ingredients = ingredients['choices']['products']['buckets']
             ingredients.sort(key=lambda x: abs(x['doc_count'] - (total / 2)))
-            prefilter['ingredients'] = ingredients
+            prefilter['ingredients'] = {'buckets': ingredients}
 
         facets = {}
         for field, content in results['aggregations']['prefilter'].items():

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -123,7 +123,7 @@ class RecipeSearch(QueryRepository):
 
     def _product_aggregatation(self):
         return {
-            'products': {
+            'singular': {
                 'terms': {
                     'field': 'ingredients.product.singular',
                     'order': {'_count': 'desc'},
@@ -136,7 +136,7 @@ class RecipeSearch(QueryRepository):
         product_filter = self._product_filter(include)
         product_aggregation = self._product_aggregatation()
         return {
-            'ingredients': {
+            'products': {
                 'nested': {'path': 'ingredients'},
                 'aggs': {
                     'choices': {
@@ -414,10 +414,9 @@ class RecipeSearch(QueryRepository):
             prefilter = results['aggregations']['prefilter']
             total = prefilter['doc_count']
 
-            ingredients = prefilter.pop('ingredients')
-            ingredients = ingredients['choices']['products']['buckets']
-            ingredients.sort(key=lambda x: abs(x['doc_count'] - (total / 2)))
-            prefilter['ingredients'] = {'buckets': ingredients}
+            products = prefilter['products']['choices']['singular']['buckets']
+            products.sort(key=lambda x: abs(x['doc_count'] - (total / 2)))
+            prefilter['products'] = {'buckets': products}
 
         facets = {}
         for field, content in results['aggregations']['prefilter'].items():

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -373,3 +373,90 @@ class RecipeSearch(QueryRepository):
             'facets': facets,
             'refinements': [refinement] if recipes and refinement else []
         }
+
+    def _render_explore_query(self, include, exclude, dietary_properties):
+        query = self._generate_post_filter({}, dietary_properties)
+        query['bool']['must'] += self._generate_include_exact_clause(include)
+        query['bool']['must_not'] += self._generate_exclude_clause(exclude)
+        sort_method = [{'rating': 'desc'}]
+        return query, sort_method
+
+    def _product_filter(self, include):
+        return {
+            'bool': {
+                'must_not': [
+                    # Do not present staple ingredients as choices
+                    {'term': {'ingredients.product.is_kitchen_staple': True}}
+                ] + [
+                    # Do not present already-selected ingredients as choices
+                    {'term': {'ingredients.product.singular': inc}}
+                    for inc in include
+                ]
+            }
+        }
+
+    def _product_aggregatation(self):
+        return {
+            'products': {
+                'terms': {
+                    'field': 'ingredients.product.singular',
+                    'order': {'_count': 'desc'},
+                    'size': 5
+                }
+            }
+        }
+
+    def _render_explore_aggregations(self, include):
+        product_filter = self._product_filter(include)
+        product_aggregation = self._product_aggregatation()
+        return {
+            'prefilter': {
+                'filter': {'match_all': {}},
+                'aggs': {
+                    'ingredients': {
+                        'nested': {'path': 'ingredients'},
+                        'aggs': {
+                            'choices': {
+                                'filter': product_filter,
+                                'aggs': product_aggregation,
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+    def explore(self, include, exclude, dietary_properties):
+        depth = len(include) + len(exclude)
+        limit = 10 if depth >= 3 else 0
+        query, sort_method = self._render_explore_query(
+            include=include,
+            exclude=exclude,
+            dietary_properties=dietary_properties
+        )
+        aggregations = self._render_explore_aggregations(include)
+        results = self.es.search(
+            index='recipes',
+            body={
+                'query': query,
+                'size': limit,
+                'sort': sort_method,
+                'aggs': aggregations,
+            }
+        )
+
+        prefiltered = results['aggregations']['prefilter']
+        total = prefiltered['doc_count']
+        choices = prefiltered['ingredients']['choices']['products']['buckets']
+        choices.sort(key=lambda choice: abs(choice['doc_count'] - (total / 2)))
+
+        recipes = []
+        for result in results['hits']['hits']:
+            recipe = Recipe.from_doc(result['_source'])
+            recipes.append(recipe.to_dict(include))
+
+        return {
+            'authority': 'api',
+            'choices': choices,
+            'results': recipes,
+        }

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -111,7 +111,7 @@ class RecipeSearch(QueryRepository):
         return {
             'bool': {
                 'must': [
-                    {'term': {f'is_{dietary_property.replace("-","_")}': True}}
+                    {'term': {f'ingredients.product.is_{dietary_property.replace("-", "_")}': True}}
                     for dietary_property in dietary_properties
                 ],
                 'must_not': [

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -457,7 +457,7 @@ class RecipeSearch(QueryRepository):
         }
 
     def explore(self, include, exclude, dietary_properties):
-        depth = len(include) + len(exclude)
+        depth = len(set(include + exclude))
         limit = 10 if depth >= 3 else 0
         return self.query(
             include=include,


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This changeset adds the `/recipes/explore` endpoint to the search API.  This endpoint is intended to support an alternative recipe navigation mechanism that is prompt-driven rather than query-driven.

The endpoint includes a list of product suggestions within the response `facets` field.  These products are determined to be the 'most selective' product options given the query parameters provided so far: they will have the largest impact on the subsequent search if included/excluded by the caller.

### Briefly summarize the changes
1. Add a 'product suggestions' aggregation
1. Allow query refinement to be disabled on-demand
1. Add the 'recipe explore' endpoint, which enables product suggestions and disables query refinement

### How have the changes been tested?
1. Local development testing