### PR TITLE
Update preferred search index field for equipment name

### DIFF
--- a/reciperadar/search/equipment.py
+++ b/reciperadar/search/equipment.py
@@ -11,15 +11,15 @@ class EquipmentSearch(QueryRepository):
               'filter': {
                 'bool': {
                   'should': [
-                    {'match': {'directions.equipment.equipment': prefix}},
-                    {'prefix': {'directions.equipment.equipment': prefix}}
+                    {'match': {'directions.equipment.name': prefix}},
+                    {'prefix': {'directions.equipment.name': prefix}}
                   ]
                 }
               },
               'aggregations': {
                 'equipment': {
                   'terms': {
-                    'field': 'directions.equipment.equipment',
+                    'field': 'directions.equipment.name',
                     'include': f'{prefix}.*',
                     'min_doc_count': 1,
                     'size': 10

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -51,7 +51,7 @@ class RecipeSearch(QueryRepository):
         conditions = defaultdict(list)
         for item in equipment:
             condition = 'filter' if item.positive else 'must_not'
-            match = {'match': {'directions.equipment.equipment': item.term}}
+            match = {'match': {'directions.equipment.name': item.term}}
             conditions[condition].append(match)
         return {'bool': conditions}
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This is a small cleanup corresponding to openculinary/backend#45.

### Briefly summarize the changes
1. Find equipment by name using recently-added 'equipment.name' field in preference to legacy 'equipment.equipment' field

**List any issues that this change relates to**
Relates to openculinary/backend#45
Relates to openculinary/knowledge-graph#62