### PR TITLE
Technical debt reduction: simplify reconstitution of equipment data

### DIFF
--- a/reciperadar/models/recipes/appliance.py
+++ b/reciperadar/models/recipes/appliance.py
@@ -1,8 +1,8 @@
 from reciperadar import db
-from reciperadar.models.base import Storable
+from reciperadar.models.recipes.equipment import DirectionEquipment
 
 
-class DirectionAppliance(Storable):
+class DirectionAppliance(DirectionEquipment):
     __tablename__ = "direction_appliances"
 
     fk = db.ForeignKey("recipe_directions.id")
@@ -16,5 +16,5 @@ class DirectionAppliance(Storable):
         appliance_id = doc.get("id") or DirectionAppliance.generate_id()
         return DirectionAppliance(
             id=appliance_id,
-            appliance=doc["appliance"],
+            appliance=doc["name"],
         )

--- a/reciperadar/models/recipes/direction.py
+++ b/reciperadar/models/recipes/direction.py
@@ -1,7 +1,6 @@
-from xml.etree import ElementTree
-
 from reciperadar import db
 from reciperadar.models.base import Storable
+from reciperadar.models.recipes.equipment import DirectionEquipment
 from reciperadar.models.recipes.appliance import DirectionAppliance
 from reciperadar.models.recipes.utensil import DirectionUtensil
 from reciperadar.models.recipes.vessel import DirectionVessel
@@ -22,49 +21,19 @@ class RecipeDirection(Storable):
     vessels = db.relationship("DirectionVessel", passive_deletes="all")
 
     @staticmethod
-    def _build_item(item, category, category_class):
-        item_classes = set(item.attrib.get("class", "").split())
-        if "equipment" not in item_classes:
-            return
-        if category not in item_classes:
-            return
-        doc = {category: item.text}
-        return category_class.from_doc(doc)
-
-    @staticmethod
-    def _parse_equipment(markup):
-        equipment = {
-            "appliances": [],
-            "utensils": [],
-            "vessels": [],
-        }
-        if not markup:
-            return equipment
-
-        category_classes = {
-            "appliances": DirectionAppliance,
-            "utensils": DirectionUtensil,
-            "vessels": DirectionVessel,
-        }
-
-        doc = ElementTree.fromstring(f"<xml>{markup}</xml>")
-        for item in doc.findall("mark"):
-            for category in equipment:
-                cls = category_classes[category]
-                obj = RecipeDirection._build_item(item, category[:-1], cls)
-                equipment[category].append(obj) if obj else None
-        return equipment
-
-    @staticmethod
     def from_doc(doc, matches=None):
         direction_id = doc.get("id") or RecipeDirection.generate_id()
-        equipment = RecipeDirection._parse_equipment(doc["markup"])
+        equipment = [
+            DirectionEquipment.from_doc(equipment) for equipment in doc["equipment"]
+        ]
         return RecipeDirection(
             id=direction_id,
             index=doc["index"],
             description=doc["description"],
             markup=doc["markup"],
-            **equipment,
+            appliances=list(filter(lambda e: type(e) == DirectionAppliance, equipment)),
+            utensils=list(filter(lambda e: type(e) == DirectionUtensil, equipment)),
+            vessels=list(filter(lambda e: type(e) == DirectionVessel, equipment)),
         )
 
     def to_dict(self):

--- a/reciperadar/models/recipes/equipment.py
+++ b/reciperadar/models/recipes/equipment.py
@@ -1,0 +1,17 @@
+from reciperadar.models.base import Storable
+
+
+class DirectionEquipment(Storable):
+    __abstract__ = True
+
+    @staticmethod
+    def from_doc(doc):
+        from reciperadar.models.recipes.appliance import DirectionAppliance
+        from reciperadar.models.recipes.utensil import DirectionUtensil
+        from reciperadar.models.recipes.vessel import DirectionVessel
+
+        return {
+            "appliance": DirectionAppliance,
+            "utensil": DirectionUtensil,
+            "vessel": DirectionVessel,
+        }[doc["category"]].from_doc(doc)

--- a/reciperadar/models/recipes/utensil.py
+++ b/reciperadar/models/recipes/utensil.py
@@ -1,8 +1,8 @@
 from reciperadar import db
-from reciperadar.models.base import Storable
+from reciperadar.models.recipes.equipment import DirectionEquipment
 
 
-class DirectionUtensil(Storable):
+class DirectionUtensil(DirectionEquipment):
     __tablename__ = "direction_utensils"
 
     fk = db.ForeignKey("recipe_directions.id")
@@ -16,5 +16,5 @@ class DirectionUtensil(Storable):
         utensil_id = doc.get("id") or DirectionUtensil.generate_id()
         return DirectionUtensil(
             id=utensil_id,
-            utensil=doc["utensil"],
+            utensil=doc["name"],
         )

--- a/reciperadar/models/recipes/vessel.py
+++ b/reciperadar/models/recipes/vessel.py
@@ -1,8 +1,8 @@
 from reciperadar import db
-from reciperadar.models.base import Storable
+from reciperadar.models.recipes.equipment import DirectionEquipment
 
 
-class DirectionVessel(Storable):
+class DirectionVessel(DirectionEquipment):
     __tablename__ = "direction_vessels"
 
     fk = db.ForeignKey("recipe_directions.id")
@@ -16,5 +16,5 @@ class DirectionVessel(Storable):
         vessel_id = doc.get("id") or DirectionVessel.generate_id()
         return DirectionVessel(
             id=vessel_id,
-            vessel=doc["vessel"],
+            vessel=doc["name"],
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,10 +16,11 @@ def raw_recipe_hit():
         "_id": "random-id",
         "_score": 10.04635,
         "_source": {
-            "id": "example_id",
+            "id": "recipe_id_0",
             "title": "Test Recipe",
             "directions": [
                 {
+                    "id": "direction_id_0",
                     "index": 0,
                     "description": "place each skewer in the oven",
                     "markup": (
@@ -27,10 +28,23 @@ def raw_recipe_hit():
                         "<mark class='equipment utensil'>skewer</mark> in the "
                         "<mark class='equipment appliance'>oven</mark>"
                     ),
+                    "equipment": [
+                        {
+                            "id": "equipment_id_0",
+                            "name": "skewer",
+                            "category": "utensil",
+                        },
+                        {
+                            "id": "equipment_id_1",
+                            "name": "oven",
+                            "category": "appliance",
+                        },
+                    ],
                 }
             ],
             "ingredients": [
                 {
+                    "id": "ingredient_id_0",
                     "index": 0,
                     "description": "1 unit of test ingredient one",
                     "product": {
@@ -45,6 +59,7 @@ def raw_recipe_hit():
                     "product_is_plural": False,
                     "product_name": "one",
                     "nutrition": {
+                        "id": "nutrition_id_0",
                         "carbohydrates": 0,
                         "carbohydrates_units": "g",
                         "energy": 0,
@@ -58,6 +73,7 @@ def raw_recipe_hit():
                     },
                 },
                 {
+                    "id": "ingredient_id_1",
                     "index": 1,
                     "description": "two units of test ingredient two",
                     "product": {"singular": "two"},


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This is a technical debt cleanup; when support for `equipment` (appliances, utensils, vessels) contained within recipe directions was added, the representation of each item of equipment within a direction step was only available within the `markup` (XML) field on the direction.

Directions are currently disabled in the user-facing interface, but we do include the relevant fields in the search engine index -- and that means we're parsing the markup when we load documents.

Instead of parsing the XML, reconstitute the equipment from the dedicated `equipment` field within each direction.

### Briefly summarize the changes
1. Introduce a `DirectionEquipment` base class that `DirectionAppliance`, `DirectionUtensil`, `DirectionVessel` all inherit from
2. When reconstruction equipment fields from a document, read from the `equipment` field instead of parsing the `markup` field

### How have the changes been tested?
1. Unit test coverage is updated