### PR TITLE
Introduce ingredient synonym expansion at query-time

### DIFF
--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -53,7 +53,8 @@ def load_ingredient_synonyms():
         app.ingredient_synonyms_loaded_at = datetime.utcnow()
 
     # Return the latest-known synonyms
-    return app.ingredient_synonyms
+    if hasattr(app, "ingredient_synonyms"):
+        return app.ingredient_synonyms
 
 
 @app.route("/recipes/search")

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -75,7 +75,7 @@ def recipe_search():
     # Perform a recrawl for the search to find any new/missing recipes
     equipment = EntityClause.term_list(equipment)
     include = EntityClause.term_list(ingredients, None, lambda x: x.positive)
-    exclude = EntityClause.term_list(ingredients, None, lambda x: not x.positive)
+    exclude = EntityClause.term_list(ingredients, None, lambda x: x.negative)
     recrawl_search.delay(include, exclude, equipment, offset)
 
     # Log a search event
@@ -113,7 +113,7 @@ def recipe_explore():
 
     # TODO: De-duplicate this logic; it also appears in RecipeSearch.explore
     include = EntityClause.term_list(ingredients, None, lambda x: x.positive)
-    exclude = EntityClause.term_list(ingredients, None, lambda x: not x.positive)
+    exclude = EntityClause.term_list(ingredients, None, lambda x: x.negative)
     depth = len(ingredients)
     limit = 10 if depth >= 3 else 0
 

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -44,8 +44,10 @@ def load_ingredient_synonyms():
     if hasattr(app, "ingredient_synonyms"):
         if datetime.utcnow() < app.ingredient_synonyms_loaded_at + timedelta(hours=1):
             return app.ingredient_synonyms
-    app.ingredient_synonyms = IngredientSearch().synonyms()
-    app.ingredient_synonyms_loaded_at = datetime.utcnow()
+    synonyms = IngredientSearch().synonyms()
+    if synonyms:
+        app.ingredient_synonyms = synonyms
+        app.ingredient_synonyms_loaded_at = datetime.utcnow()
     return app.ingredient_synonyms
 
 

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -41,13 +41,18 @@ def dietary_args(args):
 
 @app.before_first_request
 def load_ingredient_synonyms():
+    # Return cached synonyms if they are available and have not yet expired
     if hasattr(app, "ingredient_synonyms"):
         if datetime.utcnow() < app.ingredient_synonyms_loaded_at + timedelta(hours=1):
             return app.ingredient_synonyms
+
+    # Attempt to update the synonym cache
     synonyms = IngredientSearch().synonyms()
     if synonyms:
         app.ingredient_synonyms = synonyms
         app.ingredient_synonyms_loaded_at = datetime.utcnow()
+
+    # Return the latest-known synonyms
     return app.ingredient_synonyms
 
 

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -1,9 +1,12 @@
+from datetime import datetime, timedelta
+
 from flask import abort, jsonify, request
 from user_agents import parse as ua_parser
 
 from reciperadar import app
 from reciperadar.models.recipes import Recipe
 from reciperadar.search.base import EntityClause
+from reciperadar.search.ingredients import IngredientSearch
 from reciperadar.search.recipes import RecipeSearch
 from reciperadar.workers.events import store_event
 from reciperadar.workers.searches import recrawl_search
@@ -34,6 +37,16 @@ def dietary_args(args):
             "vegetarian",
         }
     ]
+
+
+@app.before_first_request
+def load_ingredient_synonyms():
+    if hasattr(app, "ingredient_synonyms"):
+        if datetime.utcnow() < app.ingredient_synonyms_loaded_at + timedelta(hours=1):
+            return app.ingredient_synonyms
+    app.ingredient_synonyms = IngredientSearch().synonyms()
+    app.ingredient_synonyms_loaded_at = datetime.utcnow()
+    return app.ingredient_synonyms
 
 
 @app.route("/recipes/search")
@@ -73,9 +86,10 @@ def recipe_search():
     suspected_bot = ua_parser(user_agent or "").is_bot
 
     # Perform a recrawl for the search to find any new/missing recipes
+    synonyms = load_ingredient_synonyms()
     equipment = EntityClause.term_list(equipment)
-    include = EntityClause.term_list(ingredients, lambda x: x.positive)
-    exclude = EntityClause.term_list(ingredients, lambda x: not x.positive)
+    include = EntityClause.term_list(ingredients, synonyms, lambda x: x.positive)
+    exclude = EntityClause.term_list(ingredients, synonyms, lambda x: not x.positive)
     recrawl_search.delay(include, exclude, equipment, offset)
 
     # Log a search event
@@ -112,8 +126,9 @@ def recipe_explore():
     suspected_bot = ua_parser(user_agent or "").is_bot
 
     # TODO: De-duplicate this logic; it also appears in RecipeSearch.explore
-    include = EntityClause.term_list(ingredients, lambda x: x.positive)
-    exclude = EntityClause.term_list(ingredients, lambda x: not x.positive)
+    synonyms = load_ingredient_synonyms()
+    include = EntityClause.term_list(ingredients, synonyms, lambda x: x.positive)
+    exclude = EntityClause.term_list(ingredients, synonyms, lambda x: not x.positive)
     depth = len(ingredients)
     limit = 10 if depth >= 3 else 0
 

--- a/reciperadar/models/recipes/product.py
+++ b/reciperadar/models/recipes/product.py
@@ -38,7 +38,7 @@ class Product(Storable):
             True: Product.STATE_AVAILABLE,
             False: Product.STATE_REQUIRED,
         }
-        include = EntityClause.term_list(ingredients, lambda x: x.positive)
+        include = EntityClause.term_list(ingredients, None, lambda x: x.positive)
         available = bool(set(self.contents or []) & set(include))
         return states[available]
 

--- a/reciperadar/search/base.py
+++ b/reciperadar/search/base.py
@@ -8,6 +8,10 @@ class EntityClause(object):
         self.term = term
         self.positive = positive
 
+    @property
+    def negative(self):
+        return not self.positive
+
     @staticmethod
     def from_arg(arg):
         return EntityClause(arg.lstrip("-"), positive=not arg.startswith("-"))

--- a/reciperadar/search/base.py
+++ b/reciperadar/search/base.py
@@ -17,8 +17,13 @@ class EntityClause(object):
         return [EntityClause.from_arg(arg) for arg in args]
 
     @staticmethod
-    def term_list(clauses, condition=lambda x: True):
-        return list(set(map(lambda x: x.term, filter(condition, clauses))))
+    def term_list(clauses, synonyms=None, condition=lambda x: True):
+        synonyms = synonyms or {}
+        terms = set()
+        for clause in filter(condition, clauses):
+            for expansion in synonyms.get(clause.term) or [clause.term]:
+                terms.add(expansion)
+        return list(terms)
 
 
 class QueryRepository(object):

--- a/reciperadar/search/ingredients.py
+++ b/reciperadar/search/ingredients.py
@@ -120,3 +120,7 @@ class IngredientSearch(QueryRepository):
             }
             for suggestion in suggestions
         ]
+
+    def synonyms(self):
+        results = self.es.search(index="product_synonyms", size=10000)["hits"]["hits"]
+        return {result["_id"]: result["_source"]["synonyms"] for result in results}

--- a/reciperadar/search/ingredients.py
+++ b/reciperadar/search/ingredients.py
@@ -122,5 +122,11 @@ class IngredientSearch(QueryRepository):
         ]
 
     def synonyms(self):
-        results = self.es.search(index="product_synonyms", size=10000)["hits"]["hits"]
-        return {result["_id"]: result["_source"]["synonyms"] for result in results}
+        try:
+            results = self.es.search(index="product_synonyms", size=10000)
+        except Exception:
+            return None
+        return {
+            result["_id"]: result["_source"]["synonyms"]
+            for result in results["hits"]["hits"]
+        }

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -7,7 +7,7 @@ from reciperadar.search.base import EntityClause, QueryRepository
 class RecipeSearch(QueryRepository):
     @staticmethod
     def _generate_include_clause(ingredients):
-        include = EntityClause.term_list(ingredients, lambda x: x.positive)
+        include = EntityClause.term_list(ingredients, None, lambda x: x.positive)
         return [
             {
                 "constant_score": {
@@ -20,7 +20,7 @@ class RecipeSearch(QueryRepository):
 
     @staticmethod
     def _generate_include_exact_clause(ingredients):
-        include = EntityClause.term_list(ingredients, lambda x: x.positive)
+        include = EntityClause.term_list(ingredients, None, lambda x: x.positive)
         return [
             {
                 "nested": {

--- a/tests/api/test_recipes.py
+++ b/tests/api/test_recipes.py
@@ -16,8 +16,9 @@ def test_search_invalid_sort(query, client):
 
 @patch("reciperadar.api.recipes.recrawl_search.delay")
 @patch("reciperadar.api.recipes.store_event")
+@patch("reciperadar.api.recipes.load_ingredient_synonyms")
 @patch("reciperadar.search.base.QueryRepository.es.search")
-def test_search_empty_query(search, store, recrawl, client, raw_recipe_hit):
+def test_search_empty_query(search, synonyms, store, recrawl, client, raw_recipe_hit):
     hits = [raw_recipe_hit]
     total = len(hits)
     search.return_value = {
@@ -29,6 +30,7 @@ def test_search_empty_query(search, store, recrawl, client, raw_recipe_hit):
             }
         },
     }
+    synonyms.return_value = {}
 
     response = client.get("/recipes/search")
 

--- a/tests/api/test_recipes.py
+++ b/tests/api/test_recipes.py
@@ -16,7 +16,7 @@ def test_search_invalid_sort(query, client):
 
 @patch("reciperadar.api.recipes.recrawl_search.delay")
 @patch("reciperadar.api.recipes.store_event")
-@patch("reciperadar.api.recipes.load_ingredient_synonyms")
+@patch("reciperadar.search.recipes.load_ingredient_synonyms")
 @patch("reciperadar.search.base.QueryRepository.es.search")
 def test_search_empty_query(search, synonyms, store, recrawl, client, raw_recipe_hit):
     hits = [raw_recipe_hit]

--- a/tests/search/test_base.py
+++ b/tests/search/test_base.py
@@ -13,3 +13,14 @@ def test_entity_clause_parsing():
     actual_results = [(clause.term, clause.positive) for clause in clauses]
 
     assert expected_results == actual_results
+
+
+def test_entity_clause_term_list_expansion():
+    args = ["coriander", "basil"]
+    clauses = EntityClause.from_args(args)
+    synonyms = {"coriander": ["cilantro", "coriander"]}
+
+    expected_results = ["basil", "cilantro", "coriander"]
+    actual_results = EntityClause.term_list(clauses, synonyms=synonyms)
+
+    assert set(expected_results) == set(actual_results)


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This changeset allows the user to search for an ingredient name like `coriander` that may have multiple synonyms and to find recipes with ingredient lines that mention those synonym names (such as `cilantro`).

### Briefly summarize the changes
1. Load and maintain an hourly-updated cache of ingredient synonyms retrieved from a dedicated search index
1. After parsing user-provided ingredient terms, expand the term list(s) based on known ingredient synonyms

### How have the changes been tested?
1. Unit test coverage is updated
1. Workflow has been smoke-tested locally with Kubernetes + Elasticsearch + RabbitMQ

**List any issues that this change relates to**
Relates to openculinary/backend#54.