### PR TITLE
Use more-idiomatic storage of application context state within Flask

### DIFF
--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -15,7 +15,7 @@ def load_ingredient_synonyms():
         if datetime.utcnow() < g.ingredient_synonyms_loaded_at + timedelta(hours=1):
             return g.ingredient_synonyms
 
-    # Attempt to update the synonym cache
+    # Otherwise, attempt to update the synonym cache
     synonyms = IngredientSearch().synonyms()
     if synonyms:
         g.ingredient_synonyms = synonyms

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
+from flask import g
 
 from reciperadar import app
 from reciperadar.models.recipes import Recipe
@@ -10,19 +11,19 @@ from reciperadar.search.ingredients import IngredientSearch
 @app.before_first_request
 def load_ingredient_synonyms():
     # Return cached synonyms if they are available and have not yet expired
-    if hasattr(app, "ingredient_synonyms"):
-        if datetime.utcnow() < app.ingredient_synonyms_loaded_at + timedelta(hours=1):
-            return app.ingredient_synonyms
+    if "ingredient_synonyms" in g:
+        if datetime.utcnow() < g.ingredient_synonyms_loaded_at + timedelta(hours=1):
+            return g.ingredient_synonyms
 
     # Attempt to update the synonym cache
     synonyms = IngredientSearch().synonyms()
     if synonyms:
-        app.ingredient_synonyms = synonyms
-        app.ingredient_synonyms_loaded_at = datetime.utcnow()
+        g.ingredient_synonyms = synonyms
+        g.ingredient_synonyms_loaded_at = datetime.utcnow()
 
     # Return the latest-known synonyms
-    if hasattr(app, "ingredient_synonyms"):
-        return app.ingredient_synonyms
+    if "ingredient_synonyms" in g:
+        return g.ingredient_synonyms
 
 
 class RecipeSearch(QueryRepository):


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
This is largely a code-style and consistency cleanup.

### Briefly summarize the changes
1. Use the `flask.g` global application context object to store cached state, as per the [`flask` documentation](https://flask.palletsprojects.com/en/2.1.x/api/#flask.g)

(note that this object isn't guaranteed to be re-used across requests within the process lifetime; it is possible for it to be re-instantiated per-request)

### How have the changes been tested?
1. Local development testing

**List any issues that this change relates to**
Relates to openculinary/backend#54.