### PR TITLE
Fixup: don't truncate feedback issue description text

### DIFF
--- a/reciperadar/models/feedback.py
+++ b/reciperadar/models/feedback.py
@@ -9,8 +9,8 @@ class Feedback(object):
         from reciperadar import app, mail
 
         with app.app_context():
-            title = issue.pop("issue") or "(empty)"
-            title = title if len(title) < 25 else f"{title[:25]}..."
+            issue = issue.pop("issue") or "(empty)"
+            title = issue if len(issue) < 25 else f"{issue[:25]}..."
 
             html = "<html><body><table>"
             for k, v in issue.items():
@@ -18,7 +18,7 @@ class Feedback(object):
                 html += f"<th>{k}</th>"
                 html += f"<td>{v}</td>"
                 html += "</tr>"
-            html += f"</table><hr /><p>{title}</p></body></html>"
+            html += f"</table><hr /><p>{issue}</p></body></html>"
 
             message = Message(
                 subject=f"User feedback: {title}",


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Feedback sent by users has been incorrectly truncated to a maximum of 25 characters; this is the same length as the snippet of the description that is used to generate an email subject when distributing the feedback item.

### Briefly summarize the changes
1. Retain the complete feedback description text alongside the 25-character-maximum snippet used to create an email subject line.
2. As discussed in the [description of the relevant GitHub issue thread](https://github.com/openculinary/api/issues/110#issue-1819944497), a size limit was considered for the feedback text input box.  This has not yet been added - it may be in future, only if necessary.

### How have the changes been tested?
1. Not tested.

**List any issues that this change relates to**
Fixes #110.