### PR TITLE
Implementation: HTML anchor 'ping' event redirect handler

### DIFF
--- a/reciperadar/api/redirect.py
+++ b/reciperadar/api/redirect.py
@@ -16,11 +16,12 @@ def recipe_redirect(recipe_id):
         event_data={
             "recipe_id": recipe.id,
             "domain": recipe.domain,
-            "src": recipe.src,
+            "from_url": request.form.get("Ping-From") or request.headers.get("Referer"),
+            "to_url": recipe.dst,
         },
     )
 
     if request.method == "GET":
-        return redirect(recipe.src, code=301)
+        return redirect(recipe.dst, code=301)
     else:
         return jsonify({})

--- a/reciperadar/api/redirect.py
+++ b/reciperadar/api/redirect.py
@@ -1,11 +1,11 @@
-from flask import abort, redirect
+from flask import abort, jsonify, redirect, request
 
 from reciperadar import app
 from reciperadar.models.recipes import Recipe
 from reciperadar.workers.events import store_event
 
 
-@app.route("/redirect/recipe/<recipe_id>")
+@app.route("/redirect/recipe/<recipe_id>", methods=["GET", "POST"])
 def recipe_redirect(recipe_id):
     recipe = Recipe().get_by_id(recipe_id)
     if not recipe:
@@ -20,4 +20,7 @@ def recipe_redirect(recipe_id):
         },
     )
 
-    return redirect(recipe.src, code=301)
+    if request.method == "GET":
+        return redirect(recipe.src, code=301)
+    else:
+        return jsonify({})

--- a/reciperadar/api/redirect.py
+++ b/reciperadar/api/redirect.py
@@ -16,8 +16,7 @@ def recipe_redirect(recipe_id):
         event_data={
             "recipe_id": recipe.id,
             "domain": recipe.domain,
-            "from_url": request.form.get("Ping-From") or request.headers.get("Referer"),
-            "to_url": recipe.dst,
+            "dst": recipe.dst,
         },
     )
 

--- a/tests/api/test_redirect.py
+++ b/tests/api/test_redirect.py
@@ -9,7 +9,8 @@ def _expected_redirect_call(recipe):
         event_data={
             "recipe_id": recipe.id,
             "domain": recipe.domain,
-            "src": recipe.src,
+            "from_url": "http://example.org/origin",
+            "to_url": recipe.dst,
         },
     )
 
@@ -17,23 +18,32 @@ def _expected_redirect_call(recipe):
 @patch("reciperadar.api.recipes.store_event.delay")
 @patch.object(Recipe, "get_by_id")
 def test_redirect_retrieval(get_recipe_by_id, store_event, client):
-    recipe = Recipe(id="example_id", domain="example.org", src="http://example.org")
+    recipe = Recipe(id="example_id", domain="example.org", dst="http://example.org")
     get_recipe_by_id.return_value = recipe
 
-    response = client.get("/redirect/recipe/example_id")
+    response = client.get(
+        path="/redirect/recipe/example_id",
+        headers={"Referer": "http://example.org/origin"},
+    )
 
     assert response.status_code == 301
-    assert response.location == recipe.src
+    assert response.location == recipe.dst
     assert store_event.call_args == _expected_redirect_call(recipe)
 
 
 @patch("reciperadar.api.recipes.store_event.delay")
 @patch.object(Recipe, "get_by_id")
 def test_redirect_ping(get_recipe_by_id, store_event, client):
-    recipe = Recipe(id="example_id", domain="example.org", src="http://example.org")
+    recipe = Recipe(id="example_id", domain="example.org", dst="http://example.org")
     get_recipe_by_id.return_value = recipe
 
-    response = client.post("/redirect/recipe/example_id")
+    response = client.post(
+        path="/redirect/recipe/example_id",
+        data={
+            "Ping-From": "http://example.org/origin",
+            "Ping-To": recipe.dst,
+        },
+    )
 
     assert response.status_code == 200
     assert store_event.call_args == _expected_redirect_call(recipe)

--- a/tests/api/test_redirect.py
+++ b/tests/api/test_redirect.py
@@ -1,0 +1,39 @@
+from unittest.mock import call, patch
+
+from reciperadar.models.recipes import Recipe
+
+
+def _expected_redirect_call(recipe):
+    return call(
+        event_table="redirects",
+        event_data={
+            "recipe_id": recipe.id,
+            "domain": recipe.domain,
+            "src": recipe.src,
+        },
+    )
+
+
+@patch("reciperadar.api.recipes.store_event.delay")
+@patch.object(Recipe, "get_by_id")
+def test_redirect_retrieval(get_recipe_by_id, store_event, client):
+    recipe = Recipe(id="example_id", domain="example.org", src="http://example.org")
+    get_recipe_by_id.return_value = recipe
+
+    response = client.get("/redirect/recipe/example_id")
+
+    assert response.status_code == 301
+    assert response.location == recipe.src
+    assert store_event.call_args == _expected_redirect_call(recipe)
+
+
+@patch("reciperadar.api.recipes.store_event.delay")
+@patch.object(Recipe, "get_by_id")
+def test_redirect_ping(get_recipe_by_id, store_event, client):
+    recipe = Recipe(id="example_id", domain="example.org", src="http://example.org")
+    get_recipe_by_id.return_value = recipe
+
+    response = client.post("/redirect/recipe/example_id")
+
+    assert response.status_code == 200
+    assert store_event.call_args == _expected_redirect_call(recipe)

--- a/tests/api/test_redirect.py
+++ b/tests/api/test_redirect.py
@@ -9,8 +9,7 @@ def _expected_redirect_call(recipe):
         event_data={
             "recipe_id": recipe.id,
             "domain": recipe.domain,
-            "from_url": "http://example.org/origin",
-            "to_url": recipe.dst,
+            "dst": recipe.dst,
         },
     )
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Adds an HTTP `POST` handler to the `/redirect/recipe/<recipe_id>` endpoint, to implement server-side handling of [HTML anchor (`a`) `ping` events](https://html.spec.whatwg.org/multipage/links.html#hyperlink-auditing).

### Briefly summarize the changes
1. Add `POST` handler that does _not_ forward the client to the intended URL (to avoid double-clicks at the destination for any clients that attempt to follow redirect responses from the `POST` handler).
2. Also prefer to redirect users to the recipe `dst` instead of `src` - see openculinary/backend#77.

### How have the changes been tested?
1. Local development testing.
2. Unit test coverage is provided.

**List any issues that this change relates to**
Resolves #112.