### PR TITLE
Search: simplify equipment queries by using the recently-added 'equipment_names' recipe property

### DIFF
--- a/reciperadar/search/equipment.py
+++ b/reciperadar/search/equipment.py
@@ -10,15 +10,15 @@ class EquipmentSearch(QueryRepository):
                     "filter": {
                         "bool": {
                             "should": [
-                                {"match": {"directions.equipment.name": prefix}},
-                                {"prefix": {"directions.equipment.name": prefix}},
+                                {"match": {"equipment_names": prefix}},
+                                {"prefix": {"equipment_names": prefix}},
                             ]
                         }
                     },
                     "aggregations": {
                         "equipment": {
                             "terms": {
-                                "field": "directions.equipment.name",
+                                "field": "equipment_names",
                                 "include": f"{prefix}.*",
                                 "min_doc_count": 1,
                                 "size": 10,

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -76,7 +76,7 @@ class RecipeSearch(QueryRepository):
         conditions = defaultdict(list)
         for item in equipment:
             condition = "filter" if item.positive else "must_not"
-            match = {"match": {"directions.equipment.name": item.term}}
+            match = {"match": {"equipment_names": item.term}}
             conditions[condition].append(match)
         return {"bool": conditions}
 


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Cleanup / simplification made possible thanks to changes in openculinary/backend#80.

### Briefly summarize the changes
1. Use the recently-indexed `equipment_names` top-level property on indexed recipe documents instead of the nested (and no-longer-existent) `directions.equipment.name` property.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Relates to openculinary/backend#80.