### PR TITLE
Search ranking: use input query term order, instead of recipe rating, as a tie-breaker

### DIFF
--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -82,7 +82,7 @@ class RecipeSearch(QueryRepository):
 
     @staticmethod
     def sort_methods(match_count=1):
-        score_limit = pow(10, match_count) * 2
+        score_limit = pow(10, match_count) * 2.0
         preamble = f"""
             def product_count = doc.product_count.value;
             def exact_found_count = 0;

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -95,7 +95,7 @@ class RecipeSearch(QueryRepository):
             def exact_missing_count = product_count - exact_found_count;
 
             def relevance_score = (found_count * 2 + exact_found_count);
-            def normalized_score = _score / {score_limit};
+            def normalized_score = _score / {float(score_limit)};
             def missing_score = (exact_missing_count * 2 - missing_count);
             def missing_ratio = missing_count / product_count;
         """

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -82,7 +82,7 @@ class RecipeSearch(QueryRepository):
 
     @staticmethod
     def sort_methods(match_count=1):
-        score_limit = pow(10, match_count)
+        score_limit = pow(10, match_count) * 2
         preamble = f"""
             def product_count = doc.product_count.value;
             def exact_found_count = 0;

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -81,34 +81,35 @@ class RecipeSearch(QueryRepository):
         return {"bool": conditions}
 
     @staticmethod
-    def sort_methods():
-        preamble = """
+    def sort_methods(match_count=1):
+        score_limit = pow(10, match_count)
+        preamble = f"""
             def product_count = doc.product_count.value;
             def exact_found_count = 0;
             def found_count = 0;
-            for (def score = (long) _score; score > 0; score /= 10) {
+            for (def score = (long) _score; score > 0; score /= 10) {{
                 if (score % 10 > 2) exact_found_count++;
                 if (score % 10 > 0) found_count++;
-            }
+            }}
             def missing_count = product_count - found_count;
             def exact_missing_count = product_count - exact_found_count;
 
             def relevance_score = (found_count * 2 + exact_found_count);
-            def normalized_rating = doc.rating.value / 10;
+            def normalized_score = _score / {score_limit} / 10;
             def missing_score = (exact_missing_count * 2 - missing_count);
             def missing_ratio = missing_count / product_count;
         """
         return {
             # rank: number of ingredient matches
-            # tiebreak: recipe rating
+            # tiebreak: normalized relevance score
             "relevance": {
-                "script": f"{preamble} relevance_score + normalized_rating",
+                "script": f"{preamble} relevance_score + normalized_score",
                 "order": "desc",
             },
             # rank: number of missing ingredients
-            # tiebreak: recipe rating
+            # tiebreak: normalized relevance score
             "ingredients": {
-                "script": f"{preamble} missing_score + 1 - normalized_rating",
+                "script": f"{preamble} missing_score + 1 - normalized_score",
                 "order": "asc",
             },
             # rank: preparation time
@@ -124,9 +125,10 @@ class RecipeSearch(QueryRepository):
         if not sort:
             sort = "relevance"
         # if no ingredients are specified, we may be able to short-cut sorting
-        if not any([x.positive for x in ingredients]) and sort != "duration":
+        include = [True for x in ingredients if x.positive]
+        if include == [] and sort != "duration":
             return {"script": "doc.rating.value", "order": "desc"}
-        return self.sort_methods()[sort]
+        return self.sort_methods(match_count=len(include))[sort]
 
     def _domain_facets(self):
         return {"domains": {"terms": {"field": "domain", "size": 100}}}

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -82,7 +82,7 @@ class RecipeSearch(QueryRepository):
 
     @staticmethod
     def sort_methods(match_count=1):
-        score_limit = pow(10, match_count) * 2.0
+        score_limit = pow(10, match_count) * 2
         preamble = f"""
             def product_count = doc.product_count.value;
             def exact_found_count = 0;

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -95,7 +95,7 @@ class RecipeSearch(QueryRepository):
             def exact_missing_count = product_count - exact_found_count;
 
             def relevance_score = (found_count * 2 + exact_found_count);
-            def normalized_score = _score / {score_limit} / 10;
+            def normalized_score = _score / {score_limit};
             def missing_score = (exact_missing_count * 2 - missing_count);
             def missing_ratio = missing_count / product_count;
         """


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
In the `relevance` (default; most matches from input terms) and `ingredients` (fewest missing ingredients) search result ranking modes, we have been using the `rating` of each recipe document as a tiebreaker for results that score equally in terms of matched/missing ingredients.

Issue #115, from user feedback, describes a situation where this caused less-relevant-than-ideal results to appear in search results.

The [`constant_score` that we calculate per-recipe-document during search engine queries](https://github.com/openculinary/api/blob/d147782c47c7de5463ff7df9d47e8c82cd4290ed/reciperadar/search/recipes.py#L34-L37) is intended to use the input-supplied query term order to generate higher component sums for more-significant query terms (first term most significant, second term second-most significant, ...).  While investigating #115 and developing the branches in this branch, it turned out that there was a bug that could reorder the query terms unexpectedly, due to use of [Python's documented unordered behaviour for `set` objects](https://docs.python.org/3/library/stdtypes.html#set-types-set-frozenset).  Commit d147782c47c7de5463ff7df9d47e8c82cd4290ed resolves this, and with that fix in place, we can fairly straightforwardly swap out `rating`-based tiebreak sorting for `score`-based tiebreak sorting.

Sort-by-rating is retained when no positive query terms are supplied by the user, because in those cases we do not have any `constant_score` values to derive tiebreakers from.

### Briefly summarize the changes
1. Use the `constant_score` calculated during search engine recipe index queries, instead of the `rating` property on each recipe document returned, as a tiebreaker for most-matching-ingredients (`relevance`) and fewest-missing-ingredients (`ingredients`) sort-mode searches.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Fixes #115.