### PR TITLE
Add recipe redirection support to the API

### DIFF
--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -15,6 +15,9 @@ def recipe_view(recipe_id):
     if not recipe:
         return abort(404)
 
+    if recipe.redirected_id:
+        return recipe_view(recipe.redirected_id)
+
     results = {
         "total": 1,
         "results": [recipe.to_dict()],

--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -1,3 +1,5 @@
+import sys
+
 from flask import abort, jsonify, request
 from user_agents import parse as ua_parser
 
@@ -16,6 +18,10 @@ def recipe_view(recipe_id):
         return abort(404)
 
     if recipe.redirected_id:
+        print(
+            f"Redirecting from_id={recipe.id} to_id={recipe.redirected_id}",
+            file=sys.stderr,
+        )
         return recipe_view(recipe.redirected_id)
 
     results = {

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -31,6 +31,9 @@ class Recipe(Storable, Searchable):
 
     indexed_at = db.Column(db.DateTime)
 
+    redirected_id = db.Column(db.String, redirected_fk)
+    redirected_at = db.Column(db.DateTime)
+
     @property
     def noun(self):
         return "recipes"
@@ -86,6 +89,8 @@ class Recipe(Storable, Searchable):
             servings=doc["servings"],
             time=doc["time"],
             rating=doc["rating"],
+            redirected_id=doc.get("redirected_id"),
+            redirected_at=doc.get("redirected_at"),
         )
 
     def to_dict(self, ingredients=None):

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -89,6 +89,7 @@ class Recipe(Storable, Searchable):
             servings=doc["servings"],
             time=doc["time"],
             rating=doc["rating"],
+            indexed_at=doc["indexed_at"],
             redirected_id=doc.get("redirected_id"),
             redirected_at=doc.get("redirected_at"),
         )

--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -31,7 +31,7 @@ class Recipe(Storable, Searchable):
 
     indexed_at = db.Column(db.DateTime)
 
-    redirected_id = db.Column(db.String, redirected_fk)
+    redirected_id = db.Column(db.String)
     redirected_at = db.Column(db.DateTime)
 
     @property

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,6 +89,7 @@ def raw_recipe_hit():
             "domain": "example.com",
             "servings": 2,
             "rating": 4.5,
+            "indexed_at": "1970-01-01T01:02:03.456789",
             "nutrition": {
                 "carbohydrates": 0,
                 "carbohydrates_units": "g",


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
In openculinary/backend#84 support is being added to hide known-duplicate recipe documents indexed into the search engine.

When a duplicate is detected, a redirection reference is added to the document to indicate the ID of the preferred (oldest origin) document.  Side-effect logic is added to set the `hidden` flag to `true` on these documents, so that they do not appear in search results.

However: it is possible for client API requests to perform a lookup for an individual recipe.  Typically this may occur when a user has bookmarked individual recipes (recipe `view` links), or added recipes to their 'starred' recipes (meaning that the app will re-load the information about those recipes from the server when the app is launched).

We'd like to be able to handle those requests for the deprecated/old recipe document IDs -- and we can use the `redirected_id` field, included in the search-engine indexed recipe document fields by `backend` service, to achieve this.

Note: ideally clients should identify that the recipe ID found _within_ the response has changed (despite the fact that a successful HTTP response is received using the original ID).  This would allow traffic for the legacy identifiers to gradually reduce as clients update their references.

### Briefly summarize the changes
1. If we detect that a recipe contains a non-empty `redirected_id`, then respond with the contents of the referenced recipe instead of the current document.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Relates to openculinary/backend#71.
Depends upon openculinary/backend#84.