### PR TITLE
Input validation: add presence and length validation for the 'pre' autosuggest parameter.

### DIFF
--- a/reciperadar/api/autosuggest.py
+++ b/reciperadar/api/autosuggest.py
@@ -1,4 +1,4 @@
-from flask import jsonify, request
+from flask import abort, jsonify, request
 
 from reciperadar import app
 from reciperadar.search.equipment import EquipmentSearch
@@ -7,13 +7,17 @@ from reciperadar.search.ingredients import IngredientSearch
 
 @app.route("/autosuggest/equipment")
 def equipment():
-    prefix = request.args.get("pre")
+    prefix = request.args.get("pre") or ""
+    if not (3 <= len(prefix) <= 64):
+        return abort(400)
     results = EquipmentSearch().autosuggest(prefix)
     return jsonify(results)
 
 
 @app.route("/autosuggest/ingredients")
 def ingredients():
-    prefix = request.args.get("pre")
+    prefix = request.args.get("pre") or ""
+    if not (3 <= len(prefix) <= 64):
+        return abort(400)
     results = IngredientSearch().autosuggest(prefix)
     return jsonify(results)

--- a/tests/api/test_autosuggest.py
+++ b/tests/api/test_autosuggest.py
@@ -1,0 +1,35 @@
+import pytest
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        None,
+        "",
+        "a",
+        "0",
+        "1",
+        "test" * 25,
+    ],
+)
+def test_autosuggest_equipment_invalid_prefix(client, prefix):
+    url = "/autosuggest/equipment" + (f"?pre={prefix}" if prefix else "")
+    response = client.get(url)
+    assert response.status_code == 400
+
+
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        None,
+        "",
+        "a",
+        "0",
+        "1",
+        "test" * 25,
+    ],
+)
+def test_autosuggest_ingredients_invalid_prefix(client, prefix):
+    url = "/autosuggest/ingredients" + (f"?pre={prefix}" if prefix else "")
+    response = client.get(url)
+    assert response.status_code == 400


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Although generally it is unlikely that the client should send excessively short or long autosuggest prefix strings (the `pre` query-string parameter mentioned in the title), it can happen occasionally and we could handle that fairly straightforwardly server-side.

### Briefly summarize the changes
1. Check whether the autosuggest query prefix provided by the client is within reasonable (currently: min=3, max=64) string length limits.
1. Reject invalid query prefix lengths with an HTTP 400 (invalid request) error response.

### How have the changes been tested?
1. Unit test coverage is provided.

**List any issues that this change relates to**
Resolves #119.