### PR TITLE
Draft: use derived fields to implement per-ingredient recipe scoring

### DIFF
--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -56,15 +56,7 @@ class RecipeSearch(QueryRepository):
     def _generate_include_clause(ingredients):
         synonyms = load_ingredient_synonyms()
         include = EntityClause.term_list(ingredients, lambda x: x.positive, synonyms)
-        return [
-            {
-                "constant_score": {
-                    "boost": 1,
-                    "filter": {"match": {"contents": inc}},
-                }
-            }
-            for inc in include
-        ]
+        return [{"match": {"contents": inc}} for inc in include]
 
     @staticmethod
     def _generate_include_exact_clause(ingredients):
@@ -74,12 +66,7 @@ class RecipeSearch(QueryRepository):
             {
                 "nested": {
                     "path": "ingredients",
-                    "query": {
-                        "constant_score": {
-                            "boost": 1,
-                            "filter": {"match": {"ingredients.product.singular": inc}},
-                        }
-                    },
+                    "query": {"match": {"ingredients.product.singular": inc}},
                 }
             }
             for inc in include

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -40,7 +40,9 @@ class RecipeSearch(QueryRepository):
                             if (params._source['contents'].contains(product)) {
                                 score = 1;
                                 for (ingredient in params._source['ingredients']) {
-                                    if (ingredient.product.singular == product) score = 2;
+                                    if (ingredient.product.singular == product) {
+                                        score = 2;
+                                    }
                                 }
                             }
                             emit(score);

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -27,17 +27,43 @@ def load_ingredient_synonyms():
 
 class RecipeSearch(QueryRepository):
     @staticmethod
+    def _generate_found_clause(ingredients):
+        synonyms = load_ingredient_synonyms()
+        include = EntityClause.term_list(ingredients, lambda x: x.positive, synonyms)
+        derivations = {
+            "_found": {
+                "type": "long",
+                "script": {
+                    "source": """
+                        for (product in params.products) {
+                            long score = 0;
+                            if (params._source['contents'].contains(product)) {
+                                score = 1;
+                                for (ingredient in params._source['ingredients']) {
+                                    if (ingredient.product.singular == product) score = 2;
+                                }
+                            }
+                            emit(score);
+                        }
+                    """,
+                    "params": {"products": include},
+                },
+            }
+        }
+        return derivations, [field for field in derivations]
+
+    @staticmethod
     def _generate_include_clause(ingredients):
         synonyms = load_ingredient_synonyms()
         include = EntityClause.term_list(ingredients, lambda x: x.positive, synonyms)
         return [
             {
                 "constant_score": {
-                    "boost": pow(10, idx),
+                    "boost": 1,
                     "filter": {"match": {"contents": inc}},
                 }
             }
-            for idx, inc in enumerate(reversed(include))
+            for inc in include
         ]
 
     @staticmethod
@@ -50,13 +76,13 @@ class RecipeSearch(QueryRepository):
                     "path": "ingredients",
                     "query": {
                         "constant_score": {
-                            "boost": pow(10, idx) * 2,
+                            "boost": 1,
                             "filter": {"match": {"ingredients.product.singular": inc}},
                         }
                     },
                 }
             }
-            for idx, inc in enumerate(reversed(include))
+            for inc in include
         ]
 
     @staticmethod
@@ -82,15 +108,14 @@ class RecipeSearch(QueryRepository):
         return {"bool": conditions}
 
     @staticmethod
-    def sort_methods(match_count=1):
-        score_limit = pow(10, match_count) * 2
+    def sort_methods(score_limit=1):
         preamble = f"""
             def product_count = doc.product_count.value;
             def exact_found_count = 0;
             def found_count = 0;
-            for (def score = (long) _score; score > 0; score /= 10) {{
-                if (score % 10 > 2) exact_found_count++;
-                if (score % 10 > 0) found_count++;
+            for (score in doc._found) {{
+                if (score > 1) exact_found_count++;
+                if (score > 0) found_count++;
             }}
             def missing_count = product_count - found_count;
             def exact_missing_count = product_count - exact_found_count;
@@ -129,7 +154,7 @@ class RecipeSearch(QueryRepository):
         include = [True for x in ingredients if x.positive]
         if include == [] and sort != "duration":
             return {"script": "doc.rating.value", "order": "desc"}
-        return self.sort_methods(match_count=len(include))[sort]
+        return self.sort_methods(score_limit=len(include))[sort]
 
     def _domain_facets(self):
         return {"domains": {"terms": {"field": "domain", "size": 100}}}
@@ -377,24 +402,24 @@ class RecipeSearch(QueryRepository):
         To achieve this, we use OpenSearch's query syntax to encode information
         about the quality of each match during search execution.
 
-        We use `constant_score` queries to store a power-of-ten score for each
-        query ingredient, with the value doubled for exact matches.
+        We use `derived` fields to emit a multi-valued integer score,
+        containing one value for each query ingredient -- zero for unmatched
+        ingredients, one for partial matches, and two for exact matches.
 
         For example, in a query for `onion`, `tomato`, `tofu`:
 
-                                onion   tomato  tofu        score
-        recipe 1                exact   exact   partial     300 + 30 + 1 = 331
-        recipe 2                partial no      exact       100 +  0 + 3 = 103
-        recipe 3                exact   no      exact       300 +  0 + 3 = 303
+                                onion   tomato  tofu        _found
+        recipe 1                exact   exact   partial     [2, 2, 1]
+        recipe 2                partial no      exact       [1, 0, 2]
+        recipe 3                exact   no      exact       [2, 0, 2]
 
-        This allows the final sorting stage to determine - with some small
-        possibility of error* - how many exact and inexact matches were
-        discovered for each recipe.
+        This allows the final sorting stage to determine how many exact and
+        inexact matches were discovered for each recipe.
 
-                                score   exact_matches       all_matches
-        recipe 1                331     1 + 1 + 0 = 2       1 + 1 + 1 = 3
-        recipe 2                103     0 + 0 + 1 = 1       1 + 0 + 1 = 2
-        recipe 3                303     1 + 0 + 1 = 2       1 + 0 + 1 = 2
+                                _found        exact_matches       all_matches
+        recipe 1                [2, 2, 1]     1 + 1 + 0 = 2       1 + 1 + 1 = 3
+        recipe 2                [1, 0, 2]     0 + 0 + 1 = 1       1 + 0 + 1 = 2
+        recipe 3                [2, 0, 2]     1 + 0 + 1 = 2       1 + 0 + 1 = 2
 
         At this stage we have enough information to sort the result set based
         on the number of overall matches and to use the number of exact matches
@@ -405,15 +430,12 @@ class RecipeSearch(QueryRepository):
         - (3 matches, 2 exact) recipe 1
         - (2 matches, 2 exact) recipe 3
         - (2 matches, 1 exact) recipe 2
-
-
-        * Inconsistent results and ranking errors can occur if an ingredient
-          appears multiple times in a recipe, resulting in duplicate counts
         """
         offset = max(0, offset)
         limit = max(0, limit)
         limit = min(25, limit)
 
+        derived, derived_fields = self._generate_found_clause(ingredients=ingredients)
         aggregations = self._generate_aggregations(
             suggest_products=suggest_products,
             ingredients=ingredients,
@@ -432,6 +454,8 @@ class RecipeSearch(QueryRepository):
                 index="recipes",
                 body={
                     "query": query,
+                    "derived": derived,
+                    "fields": derived_fields,
                     "from": offset,
                     "size": limit,
                     "sort": sort_method,

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -191,17 +191,12 @@ class RecipeSearch(QueryRepository):
                 "type": "long",
                 "script": {
                     "source": """
+                        def products = Collections.unmodifiableSet(params._source['ingredients'].stream().map(ingredient -> ingredient.product.singular).collect(Collectors.toSet()));
+                        def contents = Collections.unmodifiableSet(params._source['contents'].stream().collect(Collectors.toSet()));
                         for (product in params.products) {
-                            long score = 0;
-                            if (params._source['contents'].contains(product)) {
-                                score = 1;
-                                for (ingredient in params._source['ingredients']) {
-                                    if (ingredient.product.singular == product) {
-                                        score = 2;
-                                    }
-                                }
-                            }
-                            emit(score);
+                            if (products.contains(product)) emit(2);
+                            else if (contents.contains(product)) emit(1);
+                            else emit(0);
                         }
                     """,
                     "params": {"products": include},

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -257,8 +257,7 @@ class RecipeSearch(QueryRepository):
             min_include_match = len(should)
 
         return {
-            "function_score": {
-                "boost_mode": "replace",
+            "script_score": {
                 "query": {
                     "bool": {
                         "should": should,
@@ -267,7 +266,7 @@ class RecipeSearch(QueryRepository):
                         "minimum_should_match": min_include_match,
                     }
                 },
-                "script_score": {"script": {"source": sort_params["script"]}},
+                "script": {"source": sort_params["script"]},
             }
         }, [{"_score": sort_params["order"]}]
 

--- a/reciperadar/search/recipes.py
+++ b/reciperadar/search/recipes.py
@@ -27,7 +27,7 @@ def load_ingredient_synonyms():
 
 class RecipeSearch(QueryRepository):
     @staticmethod
-    def _generate_found_clause(ingredients):
+    def _generate_derived_fields(ingredients):
         synonyms = load_ingredient_synonyms()
         include = EntityClause.term_list(ingredients, lambda x: x.positive, synonyms)
         derivations = {
@@ -423,7 +423,7 @@ class RecipeSearch(QueryRepository):
         limit = max(0, limit)
         limit = min(25, limit)
 
-        derived, derived_fields = self._generate_found_clause(ingredients=ingredients)
+        derived, derived_fields = self._generate_derived_fields(ingredients=ingredients)
         aggregations = self._generate_aggregations(
             suggest_products=suggest_products,
             ingredients=ingredients,


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Duing recipe search, we currently calculate matching-scores for each ingredient against each recipe.  The implementation we've followed summates these scores -- each represented by a `constant_score` within an independent power-of-ten numeric range -- and then subsequently infers the number of exact matches and inexact matches that occurred by, essentially, inspecting the digits of that single floating-point number.

This functions as expected, but it encounters a problem when more than 38 ingredients are entered by a user; that precondition causes an overflow of the floating-point value.

This changeset implements a different approach: when a user query is performed, the query will dynamically construct a derived field -- a field that doesn't exist in the indexed recipe documents -- containing a list of boolean values with the same length as the list of query ingredients.  For each recipe, each of the boolean values may be `null` (no match for that ingredient), `false` (matched, but not exactly), or `true` (matched exactly).

(inexact-matches are for query terms such as `tofu` matching against a recipe that mentions `silken tofu` as an ingredient)

The derived field should provide a much more intuitive way to represent the match-status of each ingredient, and also it is a convenient datastructure to use when calculating total exact-match and inexact-match counts, features needed to `sort` (rank) the recipe results.

Unfortunately scoring and sorting using derived fields isn't supported in OpenSearch yet, but it may be soon.

### Briefly summarize the changes
1. Derive a multi-valued boolean `_found` field at query-time, to replace the existing implementation that multiplexes power-of-ten scores into the floating-point `_score` value.
1. Update the built-in docstring documentation accordingly.

### How have the changes been tested?
1. Local development testing (this requires an OpenSearch service instance).

**List any issues that this change relates to**
Resolves #114
Relates to https://github.com/opensearch-project/OpenSearch/issues/12281