### PR TITLE
Events: implement 'suspected_bot' logic for redirects

### DIFF
--- a/reciperadar/api/recipes.py
+++ b/reciperadar/api/recipes.py
@@ -1,12 +1,12 @@
 import sys
 
 from flask import abort, jsonify, request
-from user_agents import parse as ua_parser
 
 from reciperadar import app
 from reciperadar.models.recipes import Recipe
 from reciperadar.search.base import EntityClause
 from reciperadar.search.recipes import RecipeSearch
+from reciperadar.utils.bots import is_suspected_bot
 from reciperadar.workers.events import store_event
 from reciperadar.workers.searches import recrawl_search
 
@@ -43,14 +43,6 @@ def dietary_args(args):
             "vegetarian",
         }
     ]
-
-
-def is_suspected_bot(user_agent):
-    user_agent = user_agent or ""
-    # ref: https://github.com/ua-parser/uap-core/issues/554
-    if "HeadlessChrome" in user_agent:
-        return True
-    return ua_parser(user_agent).is_bot
 
 
 @app.route("/recipes/search")

--- a/reciperadar/api/redirect.py
+++ b/reciperadar/api/redirect.py
@@ -2,6 +2,7 @@ from flask import abort, jsonify, redirect, request
 
 from reciperadar import app
 from reciperadar.models.recipes import Recipe
+from reciperadar.utils.bots import is_suspected_bot
 from reciperadar.workers.events import store_event
 
 
@@ -11,9 +12,13 @@ def recipe_redirect(recipe_id):
     if not recipe:
         return abort(404)
 
+    user_agent = request.headers.get("user-agent")
+    suspected_bot = is_suspected_bot(user_agent)
+
     store_event.delay(
         event_table="redirects",
         event_data={
+            "suspected_bot": suspected_bot,
             "recipe_id": recipe.id,
             "domain": recipe.domain,
             "dst": recipe.dst,

--- a/reciperadar/utils/bots.py
+++ b/reciperadar/utils/bots.py
@@ -1,0 +1,9 @@
+from user_agents import parse as ua_parser
+
+
+def is_suspected_bot(user_agent):
+    user_agent = user_agent or ""
+    # ref: https://github.com/ua-parser/uap-core/issues/554
+    if "HeadlessChrome" in user_agent:
+        return True
+    return ua_parser(user_agent).is_bot

--- a/tests/api/test_redirect.py
+++ b/tests/api/test_redirect.py
@@ -7,6 +7,7 @@ def _expected_redirect_call(recipe):
     return call(
         event_table="redirects",
         event_data={
+            "suspected_bot": False,
             "recipe_id": recipe.id,
             "domain": recipe.domain,
             "dst": recipe.dst,


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Adds logging of the user-agent-derived `suspected_bot` field on redirect (click-out-to-recipe-website) events, similar to the way it is logged for search (individual-query-by-ingredients) events.

### Briefly summarize the changes
1. Relocate the suspected-bot logic into a utility module.
1. Re-use the logic when logging `redirect` events.

### How have the changes been tested?
1. Unit test coverage is provided.

**List any issues that this change relates to**
Resolves #122.