### PR TITLE
Cleanup: remove recipe website images

### DIFF
--- a/reciperadar/models/recipes/recipe.py
+++ b/reciperadar/models/recipes/recipe.py
@@ -15,7 +15,6 @@ class Recipe(Storable, Searchable):
     domain = db.Column(db.String)
     author = db.Column(db.String)
     author_url = db.Column(db.String)
-    image_src = db.Column(db.String)
     time = db.Column(db.Integer)
     servings = db.Column(db.Integer)
     rating = db.Column(db.Float)
@@ -67,7 +66,6 @@ class Recipe(Storable, Searchable):
             domain=doc["domain"],
             author=doc.get("author"),
             author_url=doc.get("author_url"),
-            image_src=doc.get("image_src"),
             ingredients=[
                 RecipeIngredient.from_doc(ingredient)
                 for ingredient in doc["ingredients"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,6 @@ def raw_recipe_hit():
                 },
             ],
             "author": "example",
-            "image_src": "http://www.example.test/path/image.png?v=123",
             "time": 30,
             "src": "http://www.example.test/recipes/test",
             "dst": "https://www.example.test/recipes/test",


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
After openculinary/backend#90, the [`backend`](https://github.com/openculinary/backend/) service does not store recipe image content any more.  As a result, we can remove the corresponding code here too.

### Briefly summarize the changes
1. Remove loading of recipe images because these no longer exist in the search index.

### How have the changes been tested?
1. Testing is pending.

**List any issues that this change relates to**
Relates-to https://github.com/openculinary/backend/issues/89