### PR TITLE
Redirects: consider HTTP `GET` redirects as suspected bots

### DIFF
--- a/reciperadar/api/redirect.py
+++ b/reciperadar/api/redirect.py
@@ -13,7 +13,7 @@ def recipe_redirect(recipe_id):
         return abort(404)
 
     user_agent = request.headers.get("user-agent")
-    suspected_bot = is_suspected_bot(user_agent)
+    suspected_bot = request.method == "GET" or is_suspected_bot(user_agent)
 
     store_event.delay(
         event_table="redirects",

--- a/tests/api/test_redirect.py
+++ b/tests/api/test_redirect.py
@@ -3,11 +3,11 @@ from unittest.mock import call, patch
 from reciperadar.models.recipes import Recipe
 
 
-def _expected_redirect_call(recipe):
+def _expected_redirect_call(recipe, suspected_bot=False):
     return call(
         event_table="redirects",
         event_data={
-            "suspected_bot": False,
+            "suspected_bot": suspected_bot,
             "recipe_id": recipe.id,
             "domain": recipe.domain,
             "dst": recipe.dst,
@@ -28,14 +28,16 @@ def test_redirect_retrieval(get_recipe_by_id, store_event, client):
 
     assert response.status_code == 301
     assert response.location == recipe.dst
-    assert store_event.call_args == _expected_redirect_call(recipe)
+    assert store_event.call_args == _expected_redirect_call(recipe, suspected_bot=True)
 
 
+@patch("reciperadar.api.recipes.is_suspected_bot")
 @patch("reciperadar.api.recipes.store_event.delay")
 @patch.object(Recipe, "get_by_id")
-def test_redirect_ping(get_recipe_by_id, store_event, client):
+def test_redirect_ping(get_recipe_by_id, store_event, is_suspected_bot, client):
     recipe = Recipe(id="example_id", domain="example.test", dst="http://example.test")
     get_recipe_by_id.return_value = recipe
+    is_suspected_bot.return_value = False
 
     response = client.post(
         path="/redirect/recipe/example_id",


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
Generally we don't expect that the recipe redirect URLs provided by the API should be requested using HTTP GET requests -- they're made available for inclusion on HTML `ping` attributes on hyperlinks.

Begin by considering this traffic to be potential bot traffic; we may subsequently remove the `GET` redirect functionality, as described in #127.

### Briefly summarize the changes
1. Set the `suspected_bot` flag on redirects that use HTTP `GET` instead of the generally-expected HTTP `POST`.

### How have the changes been tested?
1. Unit test coverage is provided.

**List any issues that this change relates to**
Resolves #127.