### PR TITLE
Cleanup: remove ingredient/product-related nutrition

### DIFF
--- a/reciperadar/models/recipes/ingredient.py
+++ b/reciperadar/models/recipes/ingredient.py
@@ -1,6 +1,5 @@
 from reciperadar import db
 from reciperadar.models.base import Storable
-from reciperadar.models.recipes.nutrition import IngredientNutrition
 from reciperadar.models.recipes.product import Product
 
 
@@ -19,9 +18,6 @@ class RecipeIngredient(Storable):
     markup = db.Column(db.String)
 
     product = db.relationship("Product", uselist=False)
-    nutrition = db.relationship(
-        "IngredientNutrition", uselist=False, passive_deletes="all"
-    )
 
     magnitude = db.Column(db.Float)
     magnitude_parser = db.Column(db.String)
@@ -40,7 +36,6 @@ class RecipeIngredient(Storable):
 
     @staticmethod
     def from_doc(doc):
-        nutrition = doc.get("nutrition")
         return RecipeIngredient(
             id=doc["id"],
             index=doc["index"],
@@ -50,7 +45,6 @@ class RecipeIngredient(Storable):
             product_id=doc["product"].get("id"),
             product_is_plural=doc.get("product_is_plural"),
             product_parser=doc["product"].get("product_parser"),
-            nutrition=IngredientNutrition.from_doc(nutrition) if nutrition else None,
             magnitude=doc.get("magnitude"),
             magnitude_parser=doc.get("magnitude_parser"),
             units=doc.get("units"),

--- a/reciperadar/models/recipes/nutrition.py
+++ b/reciperadar/models/recipes/nutrition.py
@@ -42,29 +42,6 @@ class Nutrition(Storable):
         }
 
 
-class IngredientNutrition(Nutrition):
-    __tablename__ = "ingredient_nutrition"
-
-    fk = db.ForeignKey("recipe_ingredients.id")
-    ingredient_id = db.Column(db.String, fk)
-
-    @staticmethod
-    def from_doc(doc):
-        return IngredientNutrition(
-            id=doc["id"],
-            carbohydrates=doc.get("carbohydrates"),
-            carbohydrates_units=doc.get("carbohydrates_units"),
-            energy=doc.get("energy"),
-            energy_units=doc.get("energy_units"),
-            fat=doc.get("fat"),
-            fat_units=doc.get("fat_units"),
-            fibre=doc.get("fibre"),
-            fibre_units=doc.get("fibre_units"),
-            protein=doc.get("protein"),
-            protein_units=doc.get("protein_units"),
-        )
-
-
 class RecipeNutrition(Nutrition):
     __tablename__ = "recipe_nutrition"
 

--- a/tests/models/recipes/test_recipe.py
+++ b/tests/models/recipes/test_recipe.py
@@ -21,9 +21,6 @@ def test_recipe_from_doc(raw_recipe_hit):
     assert "nutrition" not in recipe.ingredients[0].to_dict()
     assert "is_vegetarian" in recipe.to_dict()
 
-    assert recipe.ingredients[0].nutrition.carbohydrates == 0
-    assert recipe.ingredients[0].nutrition.fibre == 0.65
-
     assert recipe.nutrition.to_dict() == {
         "carbohydrates": {"magnitude": 0, "units": "g"},
         "energy": {"magnitude": 0, "units": "cal"},


### PR DESCRIPTION
### Describe the reason for these changes and the problem that they solve
We do not plan to store ingredient/product-level nutritional information in the system in the near-term; as a result, we can simplify our data models until then.

### Briefly summarize the changes
1. Remove data models related to ingredient/product nutrition.

### How have the changes been tested?
1. Local development testing.

**List any issues that this change relates to**
Relates-to openculinary/backend#103.